### PR TITLE
feat: Optimized the inaccuracy problem of writer during json deserialization process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,7 +735,10 @@ dependencies = [
 name = "rico-wasm"
 version = "0.0.1"
 dependencies = [
+ "console_error_panic_hook",
+ "miette",
  "rico",
+ "serde",
  "serde-wasm-bindgen",
  "wasm-bindgen",
 ]

--- a/README.md
+++ b/README.md
@@ -107,17 +107,49 @@ cargo run -p benchmark
 
 ## Development
 
+### Setup
+
+```bash
+# Install insta
+curl -LsSf https://insta.rs/install.sh | sh
+
+# Install pnpm
+npm install -g pnpm bun
+
+# Install dependencies
+pnpm install
+```
+
 ### Building
+
+build crates
 
 ```bash
 cargo build --workspace
 ```
 
-### Running Tests
+build docs
 
 ```bash
-cargo test --workspace
+cargo doc --workspace
 ```
+
+build wasm
+
+````bash
+cd wasm/rico && npm run build
+```
+
+### Updating Snapshots
+
+You can for instance first run the tests and not write and new snapshots, and if you like them run the tests again and update them:
+
+```bash
+INSTA_UPDATE=no cargo test
+INSTA_UPDATE=always cargo test
+```
+
+For more information see [insta](https://insta.rs/docs/quickstart/)
 
 ### Code Structure
 
@@ -142,3 +174,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - [Logos](https://github.com/maciejhirsz/logos) for lexer generation
 - [Serde](https://github.com/serde-rs/serde) for JSON serialization
+````

--- a/creates/rico/snapshots/parser/main__snapshots__parser__common.snap
+++ b/creates/rico/snapshots/parser/main__snapshots__parser__common.snap
@@ -2585,7 +2585,7 @@ snapshot_kind: text
         "end": {
           "line": 78,
           "column": 2,
-          "index": 1772
+          "index": 1778
         }
       },
       "name": {
@@ -3021,13 +3021,13 @@ snapshot_kind: text
           "loc": {
             "start": {
               "line": 77,
-              "column": 20,
-              "index": 1751
+              "column": 26,
+              "index": 1757
             },
             "end": {
               "line": 77,
-              "column": 39,
-              "index": 1770
+              "column": 45,
+              "index": 1776
             }
           },
           "name": {
@@ -3036,13 +3036,13 @@ snapshot_kind: text
             "loc": {
               "start": {
                 "line": 77,
-                "column": 20,
-                "index": 1751
+                "column": 26,
+                "index": 1757
               },
               "end": {
                 "line": 77,
-                "column": 37,
-                "index": 1768
+                "column": 43,
+                "index": 1774
               }
             }
           },
@@ -3056,14 +3056,13 @@ snapshot_kind: text
               },
               "end": {
                 "line": 77,
-                "column": 19,
-                "index": 1750
+                "column": 25,
+                "index": 1756
               }
             },
             "value": "map",
             "valueType": {
-              "kind": "I32Keyword",
-              "value": "i32",
+              "kind": "ListType",
               "loc": {
                 "start": {
                   "line": 77,
@@ -3072,8 +3071,25 @@ snapshot_kind: text
                 },
                 "end": {
                   "line": 77,
-                  "column": 18,
-                  "index": 1749
+                  "column": 24,
+                  "index": 1755
+                }
+              },
+              "value": "list",
+              "valueType": {
+                "kind": "I32Keyword",
+                "value": "i32",
+                "loc": {
+                  "start": {
+                    "line": 77,
+                    "column": 20,
+                    "index": 1751
+                  },
+                  "end": {
+                    "line": 77,
+                    "column": 23,
+                    "index": 1754
+                  }
                 }
               }
             },
@@ -3144,12 +3160,12 @@ snapshot_kind: text
         "start": {
           "line": 81,
           "column": 1,
-          "index": 1820
+          "index": 1826
         },
         "end": {
           "line": 87,
           "column": 2,
-          "index": 2048
+          "index": 2054
         }
       },
       "name": {
@@ -3159,12 +3175,12 @@ snapshot_kind: text
           "start": {
             "line": 81,
             "column": 9,
-            "index": 1828
+            "index": 1834
           },
           "end": {
             "line": 81,
             "column": 28,
-            "index": 1847
+            "index": 1853
           }
         }
       },
@@ -3176,12 +3192,12 @@ snapshot_kind: text
             "start": {
               "line": 83,
               "column": 8,
-              "index": 1892
+              "index": 1898
             },
             "end": {
               "line": 85,
               "column": 44,
-              "index": 1995
+              "index": 2001
             }
           },
           "name": {
@@ -3191,12 +3207,12 @@ snapshot_kind: text
               "start": {
                 "line": 83,
                 "column": 8,
-                "index": 1892
+                "index": 1898
               },
               "end": {
                 "line": 83,
                 "column": 24,
-                "index": 1908
+                "index": 1914
               }
             }
           },
@@ -3207,12 +3223,12 @@ snapshot_kind: text
               "start": {
                 "line": 83,
                 "column": 3,
-                "index": 1887
+                "index": 1893
               },
               "end": {
                 "line": 83,
                 "column": 7,
-                "index": 1891
+                "index": 1897
               }
             }
           },
@@ -3223,12 +3239,12 @@ snapshot_kind: text
                 "start": {
                   "line": 83,
                   "column": 25,
-                  "index": 1909
+                  "index": 1915
                 },
                 "end": {
                   "line": 83,
                   "column": 42,
-                  "index": 1926
+                  "index": 1932
                 }
               },
               "name": {
@@ -3238,12 +3254,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 35,
-                    "index": 1919
+                    "index": 1925
                   },
                   "end": {
                     "line": 83,
                     "column": 42,
-                    "index": 1926
+                    "index": 1932
                   }
                 }
               },
@@ -3254,12 +3270,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 25,
-                    "index": 1909
+                    "index": 1915
                   },
                   "end": {
                     "line": 83,
                     "column": 26,
-                    "index": 1910
+                    "index": 1916
                   }
                 }
               },
@@ -3270,12 +3286,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 28,
-                    "index": 1912
+                    "index": 1918
                   },
                   "end": {
                     "line": 83,
                     "column": 34,
-                    "index": 1918
+                    "index": 1924
                   }
                 }
               },
@@ -3290,12 +3306,12 @@ snapshot_kind: text
                 "start": {
                   "line": 83,
                   "column": 44,
-                  "index": 1928
+                  "index": 1934
                 },
                 "end": {
                   "line": 83,
                   "column": 64,
-                  "index": 1948
+                  "index": 1954
                 }
               },
               "name": {
@@ -3305,12 +3321,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 57,
-                    "index": 1941
+                    "index": 1947
                   },
                   "end": {
                     "line": 83,
                     "column": 64,
-                    "index": 1948
+                    "index": 1954
                   }
                 }
               },
@@ -3321,12 +3337,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 44,
-                    "index": 1928
+                    "index": 1934
                   },
                   "end": {
                     "line": 83,
                     "column": 45,
-                    "index": 1929
+                    "index": 1935
                   }
                 }
               },
@@ -3336,12 +3352,12 @@ snapshot_kind: text
                   "start": {
                     "line": 83,
                     "column": 47,
-                    "index": 1931
+                    "index": 1937
                   },
                   "end": {
                     "line": 83,
                     "column": 56,
-                    "index": 1940
+                    "index": 1946
                   }
                 },
                 "value": "list",
@@ -3352,12 +3368,12 @@ snapshot_kind: text
                     "start": {
                       "line": 83,
                       "column": 52,
-                      "index": 1936
+                      "index": 1942
                     },
                     "end": {
                       "line": 83,
                       "column": 55,
-                      "index": 1939
+                      "index": 1945
                     }
                   }
                 }
@@ -3378,12 +3394,12 @@ snapshot_kind: text
                 "start": {
                   "line": 82,
                   "column": 3,
-                  "index": 1852
+                  "index": 1858
                 },
                 "end": {
                   "line": 82,
                   "column": 35,
-                  "index": 1884
+                  "index": 1890
                 }
               }
             }
@@ -3396,12 +3412,12 @@ snapshot_kind: text
             "start": {
               "line": 86,
               "column": 16,
-              "index": 2011
+              "index": 2017
             },
             "end": {
               "line": 86,
               "column": 51,
-              "index": 2046
+              "index": 2052
             }
           },
           "name": {
@@ -3411,12 +3427,12 @@ snapshot_kind: text
               "start": {
                 "line": 86,
                 "column": 16,
-                "index": 2011
+                "index": 2017
               },
               "end": {
                 "line": 86,
                 "column": 36,
-                "index": 2031
+                "index": 2037
               }
             }
           },
@@ -3426,12 +3442,12 @@ snapshot_kind: text
               "start": {
                 "line": 86,
                 "column": 3,
-                "index": 1998
+                "index": 2004
               },
               "end": {
                 "line": 86,
                 "column": 15,
-                "index": 2010
+                "index": 2016
               }
             },
             "value": "list",
@@ -3442,12 +3458,12 @@ snapshot_kind: text
                 "start": {
                   "line": 86,
                   "column": 8,
-                  "index": 2003
+                  "index": 2009
                 },
                 "end": {
                   "line": 86,
                   "column": 14,
-                  "index": 2009
+                  "index": 2015
                 }
               }
             }
@@ -3459,12 +3475,12 @@ snapshot_kind: text
                 "start": {
                   "line": 86,
                   "column": 37,
-                  "index": 2032
+                  "index": 2038
                 },
                 "end": {
                   "line": 86,
                   "column": 50,
-                  "index": 2045
+                  "index": 2051
                 }
               },
               "name": {
@@ -3474,12 +3490,12 @@ snapshot_kind: text
                   "start": {
                     "line": 86,
                     "column": 44,
-                    "index": 2039
+                    "index": 2045
                   },
                   "end": {
                     "line": 86,
                     "column": 50,
-                    "index": 2045
+                    "index": 2051
                   }
                 }
               },
@@ -3490,12 +3506,12 @@ snapshot_kind: text
                   "start": {
                     "line": 86,
                     "column": 37,
-                    "index": 2032
+                    "index": 2038
                   },
                   "end": {
                     "line": 86,
                     "column": 38,
-                    "index": 2033
+                    "index": 2039
                   }
                 }
               },
@@ -3506,12 +3522,12 @@ snapshot_kind: text
                   "start": {
                     "line": 86,
                     "column": 40,
-                    "index": 2035
+                    "index": 2041
                   },
                   "end": {
                     "line": 86,
                     "column": 43,
-                    "index": 2038
+                    "index": 2044
                   }
                 }
               },
@@ -3531,12 +3547,12 @@ snapshot_kind: text
                 "start": {
                   "line": 85,
                   "column": 3,
-                  "index": 1954
+                  "index": 1960
                 },
                 "end": {
                   "line": 85,
                   "column": 44,
-                  "index": 1995
+                  "index": 2001
                 }
               }
             }
@@ -3552,12 +3568,12 @@ snapshot_kind: text
             "start": {
               "line": 80,
               "column": 1,
-              "index": 1774
+              "index": 1780
             },
             "end": {
               "line": 80,
               "column": 46,
-              "index": 1819
+              "index": 1825
             }
           }
         }
@@ -3570,12 +3586,12 @@ snapshot_kind: text
         "start": {
           "line": 92,
           "column": 1,
-          "index": 2130
+          "index": 2136
         },
         "end": {
           "line": 96,
           "column": 2,
-          "index": 2264
+          "index": 2270
         }
       },
       "name": {
@@ -3585,12 +3601,12 @@ snapshot_kind: text
           "start": {
             "line": 92,
             "column": 8,
-            "index": 2137
+            "index": 2143
           },
           "end": {
             "line": 92,
             "column": 31,
-            "index": 2160
+            "index": 2166
           }
         }
       },
@@ -3601,12 +3617,12 @@ snapshot_kind: text
             "start": {
               "line": 93,
               "column": 3,
-              "index": 2165
+              "index": 2171
             },
             "end": {
               "line": 93,
               "column": 12,
-              "index": 2174
+              "index": 2180
             }
           },
           "name": {
@@ -3616,12 +3632,12 @@ snapshot_kind: text
               "start": {
                 "line": 93,
                 "column": 10,
-                "index": 2172
+                "index": 2178
               },
               "end": {
                 "line": 93,
                 "column": 12,
-                "index": 2174
+                "index": 2180
               }
             }
           },
@@ -3632,12 +3648,12 @@ snapshot_kind: text
               "start": {
                 "line": 93,
                 "column": 3,
-                "index": 2165
+                "index": 2171
               },
               "end": {
                 "line": 93,
                 "column": 4,
-                "index": 2166
+                "index": 2172
               }
             }
           },
@@ -3648,12 +3664,12 @@ snapshot_kind: text
               "start": {
                 "line": 93,
                 "column": 6,
-                "index": 2168
+                "index": 2174
               },
               "end": {
                 "line": 93,
                 "column": 9,
-                "index": 2171
+                "index": 2177
               }
             }
           },
@@ -3668,12 +3684,12 @@ snapshot_kind: text
             "start": {
               "line": 94,
               "column": 5,
-              "index": 2180
+              "index": 2186
             },
             "end": {
               "line": 94,
               "column": 19,
-              "index": 2194
+              "index": 2200
             }
           },
           "name": {
@@ -3683,12 +3699,12 @@ snapshot_kind: text
               "start": {
                 "line": 94,
                 "column": 15,
-                "index": 2190
+                "index": 2196
               },
               "end": {
                 "line": 94,
                 "column": 19,
-                "index": 2194
+                "index": 2200
               }
             }
           },
@@ -3699,12 +3715,12 @@ snapshot_kind: text
               "start": {
                 "line": 94,
                 "column": 5,
-                "index": 2180
+                "index": 2186
               },
               "end": {
                 "line": 94,
                 "column": 6,
-                "index": 2181
+                "index": 2187
               }
             }
           },
@@ -3715,12 +3731,12 @@ snapshot_kind: text
               "start": {
                 "line": 94,
                 "column": 8,
-                "index": 2183
+                "index": 2189
               },
               "end": {
                 "line": 94,
                 "column": 14,
-                "index": 2189
+                "index": 2195
               }
             }
           },
@@ -3735,12 +3751,12 @@ snapshot_kind: text
             "start": {
               "line": 95,
               "column": 3,
-              "index": 2247
+              "index": 2253
             },
             "end": {
               "line": 95,
               "column": 18,
-              "index": 2262
+              "index": 2268
             }
           },
           "name": {
@@ -3750,12 +3766,12 @@ snapshot_kind: text
               "start": {
                 "line": 95,
                 "column": 13,
-                "index": 2257
+                "index": 2263
               },
               "end": {
                 "line": 95,
                 "column": 18,
-                "index": 2262
+                "index": 2268
               }
             }
           },
@@ -3766,12 +3782,12 @@ snapshot_kind: text
               "start": {
                 "line": 95,
                 "column": 3,
-                "index": 2247
+                "index": 2253
               },
               "end": {
                 "line": 95,
                 "column": 4,
-                "index": 2248
+                "index": 2254
               }
             }
           },
@@ -3782,12 +3798,12 @@ snapshot_kind: text
               "start": {
                 "line": 95,
                 "column": 6,
-                "index": 2250
+                "index": 2256
               },
               "end": {
                 "line": 95,
                 "column": 12,
-                "index": 2256
+                "index": 2262
               }
             }
           },
@@ -3802,12 +3818,12 @@ snapshot_kind: text
                 "start": {
                   "line": 94,
                   "column": 21,
-                  "index": 2196
+                  "index": 2202
                 },
                 "end": {
                   "line": 94,
                   "column": 69,
-                  "index": 2244
+                  "index": 2250
                 }
               }
             }
@@ -3822,12 +3838,12 @@ snapshot_kind: text
             "start": {
               "line": 89,
               "column": 1,
-              "index": 2050
+              "index": 2056
             },
             "end": {
               "line": 89,
               "column": 51,
-              "index": 2100
+              "index": 2106
             }
           }
         },
@@ -3838,12 +3854,12 @@ snapshot_kind: text
             "start": {
               "line": 91,
               "column": 1,
-              "index": 2102
+              "index": 2108
             },
             "end": {
               "line": 91,
               "column": 28,
-              "index": 2129
+              "index": 2135
             }
           }
         }
@@ -3856,12 +3872,12 @@ snapshot_kind: text
         "start": {
           "line": 99,
           "column": 1,
-          "index": 2291
+          "index": 2297
         },
         "end": {
           "line": 103,
           "column": 2,
-          "index": 2403
+          "index": 2409
         }
       },
       "name": {
@@ -3871,12 +3887,12 @@ snapshot_kind: text
           "start": {
             "line": 99,
             "column": 8,
-            "index": 2298
+            "index": 2304
           },
           "end": {
             "line": 99,
             "column": 27,
-            "index": 2317
+            "index": 2323
           }
         }
       },
@@ -3887,12 +3903,12 @@ snapshot_kind: text
             "start": {
               "line": 100,
               "column": 3,
-              "index": 2322
+              "index": 2328
             },
             "end": {
               "line": 100,
               "column": 17,
-              "index": 2336
+              "index": 2342
             }
           },
           "name": {
@@ -3902,12 +3918,12 @@ snapshot_kind: text
               "start": {
                 "line": 100,
                 "column": 13,
-                "index": 2332
+                "index": 2338
               },
               "end": {
                 "line": 100,
                 "column": 17,
-                "index": 2336
+                "index": 2342
               }
             }
           },
@@ -3918,12 +3934,12 @@ snapshot_kind: text
               "start": {
                 "line": 100,
                 "column": 3,
-                "index": 2322
+                "index": 2328
               },
               "end": {
                 "line": 100,
                 "column": 4,
-                "index": 2323
+                "index": 2329
               }
             }
           },
@@ -3934,12 +3950,12 @@ snapshot_kind: text
               "start": {
                 "line": 100,
                 "column": 6,
-                "index": 2325
+                "index": 2331
               },
               "end": {
                 "line": 100,
                 "column": 12,
-                "index": 2331
+                "index": 2337
               }
             }
           },
@@ -3954,12 +3970,12 @@ snapshot_kind: text
             "start": {
               "line": 101,
               "column": 3,
-              "index": 2340
+              "index": 2346
             },
             "end": {
               "line": 101,
               "column": 17,
-              "index": 2354
+              "index": 2360
             }
           },
           "name": {
@@ -3969,12 +3985,12 @@ snapshot_kind: text
               "start": {
                 "line": 101,
                 "column": 13,
-                "index": 2350
+                "index": 2356
               },
               "end": {
                 "line": 101,
                 "column": 17,
-                "index": 2354
+                "index": 2360
               }
             }
           },
@@ -3985,12 +4001,12 @@ snapshot_kind: text
               "start": {
                 "line": 101,
                 "column": 3,
-                "index": 2340
+                "index": 2346
               },
               "end": {
                 "line": 101,
                 "column": 4,
-                "index": 2341
+                "index": 2347
               }
             }
           },
@@ -4001,12 +4017,12 @@ snapshot_kind: text
               "start": {
                 "line": 101,
                 "column": 6,
-                "index": 2343
+                "index": 2349
               },
               "end": {
                 "line": 101,
                 "column": 12,
-                "index": 2349
+                "index": 2355
               }
             }
           },
@@ -4021,12 +4037,12 @@ snapshot_kind: text
             "start": {
               "line": 102,
               "column": 3,
-              "index": 2391
+              "index": 2397
             },
             "end": {
               "line": 102,
               "column": 13,
-              "index": 2401
+              "index": 2407
             }
           },
           "name": {
@@ -4036,12 +4052,12 @@ snapshot_kind: text
               "start": {
                 "line": 102,
                 "column": 10,
-                "index": 2398
+                "index": 2404
               },
               "end": {
                 "line": 102,
                 "column": 13,
-                "index": 2401
+                "index": 2407
               }
             }
           },
@@ -4052,12 +4068,12 @@ snapshot_kind: text
               "start": {
                 "line": 102,
                 "column": 3,
-                "index": 2391
+                "index": 2397
               },
               "end": {
                 "line": 102,
                 "column": 4,
-                "index": 2392
+                "index": 2398
               }
             }
           },
@@ -4068,12 +4084,12 @@ snapshot_kind: text
               "start": {
                 "line": 102,
                 "column": 6,
-                "index": 2394
+                "index": 2400
               },
               "end": {
                 "line": 102,
                 "column": 9,
-                "index": 2397
+                "index": 2403
               }
             }
           },
@@ -4088,12 +4104,12 @@ snapshot_kind: text
                 "start": {
                   "line": 101,
                   "column": 19,
-                  "index": 2356
+                  "index": 2362
                 },
                 "end": {
                   "line": 101,
                   "column": 51,
-                  "index": 2388
+                  "index": 2394
                 }
               }
             }
@@ -4108,12 +4124,12 @@ snapshot_kind: text
             "start": {
               "line": 98,
               "column": 1,
-              "index": 2266
+              "index": 2272
             },
             "end": {
               "line": 98,
               "column": 25,
-              "index": 2290
+              "index": 2296
             }
           }
         }
@@ -4126,12 +4142,12 @@ snapshot_kind: text
         "start": {
           "line": 106,
           "column": 1,
-          "index": 2433
+          "index": 2439
         },
         "end": {
           "line": 110,
           "column": 2,
-          "index": 2535
+          "index": 2541
         }
       },
       "name": {
@@ -4141,12 +4157,12 @@ snapshot_kind: text
           "start": {
             "line": 106,
             "column": 8,
-            "index": 2440
+            "index": 2446
           },
           "end": {
             "line": 106,
             "column": 22,
-            "index": 2454
+            "index": 2460
           }
         }
       },
@@ -4157,12 +4173,12 @@ snapshot_kind: text
             "start": {
               "line": 107,
               "column": 3,
-              "index": 2459
+              "index": 2465
             },
             "end": {
               "line": 107,
               "column": 12,
-              "index": 2468
+              "index": 2474
             }
           },
           "name": {
@@ -4172,12 +4188,12 @@ snapshot_kind: text
               "start": {
                 "line": 107,
                 "column": 10,
-                "index": 2466
+                "index": 2472
               },
               "end": {
                 "line": 107,
                 "column": 12,
-                "index": 2468
+                "index": 2474
               }
             }
           },
@@ -4188,12 +4204,12 @@ snapshot_kind: text
               "start": {
                 "line": 107,
                 "column": 3,
-                "index": 2459
+                "index": 2465
               },
               "end": {
                 "line": 107,
                 "column": 4,
-                "index": 2460
+                "index": 2466
               }
             }
           },
@@ -4204,12 +4220,12 @@ snapshot_kind: text
               "start": {
                 "line": 107,
                 "column": 6,
-                "index": 2462
+                "index": 2468
               },
               "end": {
                 "line": 107,
                 "column": 9,
-                "index": 2465
+                "index": 2471
               }
             }
           },
@@ -4224,12 +4240,12 @@ snapshot_kind: text
             "start": {
               "line": 109,
               "column": 3,
-              "index": 2518
+              "index": 2524
             },
             "end": {
               "line": 109,
               "column": 18,
-              "index": 2533
+              "index": 2539
             }
           },
           "name": {
@@ -4239,12 +4255,12 @@ snapshot_kind: text
               "start": {
                 "line": 109,
                 "column": 13,
-                "index": 2528
+                "index": 2534
               },
               "end": {
                 "line": 109,
                 "column": 18,
-                "index": 2533
+                "index": 2539
               }
             }
           },
@@ -4255,12 +4271,12 @@ snapshot_kind: text
               "start": {
                 "line": 109,
                 "column": 3,
-                "index": 2518
+                "index": 2524
               },
               "end": {
                 "line": 109,
                 "column": 4,
-                "index": 2519
+                "index": 2525
               }
             }
           },
@@ -4271,12 +4287,12 @@ snapshot_kind: text
               "start": {
                 "line": 109,
                 "column": 6,
-                "index": 2521
+                "index": 2527
               },
               "end": {
                 "line": 109,
                 "column": 12,
-                "index": 2527
+                "index": 2533
               }
             }
           },
@@ -4291,12 +4307,12 @@ snapshot_kind: text
                 "start": {
                   "line": 108,
                   "column": 3,
-                  "index": 2472
+                  "index": 2478
                 },
                 "end": {
                   "line": 108,
                   "column": 46,
-                  "index": 2515
+                  "index": 2521
                 }
               }
             }
@@ -4311,12 +4327,12 @@ snapshot_kind: text
             "start": {
               "line": 105,
               "column": 1,
-              "index": 2405
+              "index": 2411
             },
             "end": {
               "line": 105,
               "column": 28,
-              "index": 2432
+              "index": 2438
             }
           }
         }
@@ -4329,12 +4345,12 @@ snapshot_kind: text
         "start": {
           "line": 115,
           "column": 1,
-          "index": 2668
+          "index": 2674
         },
         "end": {
           "line": 117,
           "column": 2,
-          "index": 2753
+          "index": 2759
         }
       },
       "name": {
@@ -4344,12 +4360,12 @@ snapshot_kind: text
           "start": {
             "line": 115,
             "column": 8,
-            "index": 2675
+            "index": 2681
           },
           "end": {
             "line": 115,
             "column": 22,
-            "index": 2689
+            "index": 2695
           }
         }
       },
@@ -4360,12 +4376,12 @@ snapshot_kind: text
             "start": {
               "line": 116,
               "column": 3,
-              "index": 2694
+              "index": 2700
             },
             "end": {
               "line": 116,
               "column": 17,
-              "index": 2708
+              "index": 2714
             }
           },
           "name": {
@@ -4375,12 +4391,12 @@ snapshot_kind: text
               "start": {
                 "line": 116,
                 "column": 13,
-                "index": 2704
+                "index": 2710
               },
               "end": {
                 "line": 116,
                 "column": 17,
-                "index": 2708
+                "index": 2714
               }
             }
           },
@@ -4391,12 +4407,12 @@ snapshot_kind: text
               "start": {
                 "line": 116,
                 "column": 3,
-                "index": 2694
+                "index": 2700
               },
               "end": {
                 "line": 116,
                 "column": 4,
-                "index": 2695
+                "index": 2701
               }
             }
           },
@@ -4407,12 +4423,12 @@ snapshot_kind: text
               "start": {
                 "line": 116,
                 "column": 6,
-                "index": 2697
+                "index": 2703
               },
               "end": {
                 "line": 116,
                 "column": 12,
-                "index": 2703
+                "index": 2709
               }
             }
           },
@@ -4430,12 +4446,12 @@ snapshot_kind: text
             "start": {
               "line": 112,
               "column": 1,
-              "index": 2537
+              "index": 2543
             },
             "end": {
               "line": 112,
               "column": 27,
-              "index": 2563
+              "index": 2569
             }
           }
         },
@@ -4446,12 +4462,12 @@ snapshot_kind: text
             "start": {
               "line": 113,
               "column": 1,
-              "index": 2564
+              "index": 2570
             },
             "end": {
               "line": 113,
               "column": 45,
-              "index": 2608
+              "index": 2614
             }
           }
         },
@@ -4462,12 +4478,12 @@ snapshot_kind: text
             "start": {
               "line": 114,
               "column": 1,
-              "index": 2609
+              "index": 2615
             },
             "end": {
               "line": 114,
               "column": 59,
-              "index": 2667
+              "index": 2673
             }
           }
         }
@@ -4480,12 +4496,12 @@ snapshot_kind: text
         "start": {
           "line": 120,
           "column": 1,
-          "index": 2776
+          "index": 2782
         },
         "end": {
           "line": 126,
           "column": 2,
-          "index": 2874
+          "index": 2880
         }
       },
       "name": {
@@ -4495,12 +4511,12 @@ snapshot_kind: text
           "start": {
             "line": 120,
             "column": 8,
-            "index": 2783
+            "index": 2789
           },
           "end": {
             "line": 120,
             "column": 23,
-            "index": 2798
+            "index": 2804
           }
         }
       },
@@ -4511,12 +4527,12 @@ snapshot_kind: text
             "start": {
               "line": 122,
               "column": 3,
-              "index": 2804
+              "index": 2810
             },
             "end": {
               "line": 122,
               "column": 17,
-              "index": 2818
+              "index": 2824
             }
           },
           "name": {
@@ -4526,12 +4542,12 @@ snapshot_kind: text
               "start": {
                 "line": 122,
                 "column": 13,
-                "index": 2814
+                "index": 2820
               },
               "end": {
                 "line": 122,
                 "column": 17,
-                "index": 2818
+                "index": 2824
               }
             }
           },
@@ -4542,12 +4558,12 @@ snapshot_kind: text
               "start": {
                 "line": 122,
                 "column": 3,
-                "index": 2804
+                "index": 2810
               },
               "end": {
                 "line": 122,
                 "column": 4,
-                "index": 2805
+                "index": 2811
               }
             }
           },
@@ -4558,12 +4574,12 @@ snapshot_kind: text
               "start": {
                 "line": 122,
                 "column": 6,
-                "index": 2807
+                "index": 2813
               },
               "end": {
                 "line": 122,
                 "column": 12,
-                "index": 2813
+                "index": 2819
               }
             }
           },
@@ -4581,12 +4597,12 @@ snapshot_kind: text
             "start": {
               "line": 116,
               "column": 18,
-              "index": 2709
+              "index": 2715
             },
             "end": {
               "line": 116,
               "column": 60,
-              "index": 2751
+              "index": 2757
             }
           }
         },
@@ -4597,12 +4613,12 @@ snapshot_kind: text
             "start": {
               "line": 119,
               "column": 1,
-              "index": 2755
+              "index": 2761
             },
             "end": {
               "line": 119,
               "column": 21,
-              "index": 2775
+              "index": 2781
             }
           }
         }
@@ -4615,12 +4631,12 @@ snapshot_kind: text
         "start": {
           "line": 129,
           "column": 1,
-          "index": 2889
+          "index": 2895
         },
         "end": {
           "line": 131,
           "column": 2,
-          "index": 3080
+          "index": 3086
         }
       },
       "name": {
@@ -4630,12 +4646,12 @@ snapshot_kind: text
           "start": {
             "line": 129,
             "column": 8,
-            "index": 2896
+            "index": 2902
           },
           "end": {
             "line": 129,
             "column": 23,
-            "index": 2911
+            "index": 2917
           }
         }
       },
@@ -4646,12 +4662,12 @@ snapshot_kind: text
             "start": {
               "line": 130,
               "column": 3,
-              "index": 2916
+              "index": 2922
             },
             "end": {
               "line": 130,
               "column": 165,
-              "index": 3078
+              "index": 3084
             }
           },
           "name": {
@@ -4661,12 +4677,12 @@ snapshot_kind: text
               "start": {
                 "line": 130,
                 "column": 13,
-                "index": 2926
+                "index": 2932
               },
               "end": {
                 "line": 130,
                 "column": 24,
-                "index": 2937
+                "index": 2943
               }
             }
           },
@@ -4677,12 +4693,12 @@ snapshot_kind: text
               "start": {
                 "line": 130,
                 "column": 3,
-                "index": 2916
+                "index": 2922
               },
               "end": {
                 "line": 130,
                 "column": 4,
-                "index": 2917
+                "index": 2923
               }
             }
           },
@@ -4693,12 +4709,12 @@ snapshot_kind: text
               "start": {
                 "line": 130,
                 "column": 6,
-                "index": 2919
+                "index": 2925
               },
               "end": {
                 "line": 130,
                 "column": 12,
-                "index": 2925
+                "index": 2931
               }
             }
           },
@@ -4710,12 +4726,12 @@ snapshot_kind: text
               "start": {
                 "line": 130,
                 "column": 27,
-                "index": 2940
+                "index": 2946
               },
               "end": {
                 "line": 130,
                 "column": 165,
-                "index": 3078
+                "index": 3084
               }
             }
           },
@@ -4731,12 +4747,12 @@ snapshot_kind: text
             "start": {
               "line": 125,
               "column": 3,
-              "index": 2823
+              "index": 2829
             },
             "end": {
               "line": 125,
               "column": 52,
-              "index": 2872
+              "index": 2878
             }
           }
         },
@@ -4747,12 +4763,12 @@ snapshot_kind: text
             "start": {
               "line": 128,
               "column": 1,
-              "index": 2876
+              "index": 2882
             },
             "end": {
               "line": 128,
               "column": 13,
-              "index": 2888
+              "index": 2894
             }
           }
         }
@@ -4765,12 +4781,12 @@ snapshot_kind: text
         "start": {
           "line": 134,
           "column": 1,
-          "index": 3102
+          "index": 3108
         },
         "end": {
           "line": 141,
           "column": 2,
-          "index": 3332
+          "index": 3338
         }
       },
       "name": {
@@ -4780,12 +4796,12 @@ snapshot_kind: text
           "start": {
             "line": 134,
             "column": 8,
-            "index": 3109
+            "index": 3115
           },
           "end": {
             "line": 134,
             "column": 23,
-            "index": 3124
+            "index": 3130
           }
         }
       },
@@ -4796,12 +4812,12 @@ snapshot_kind: text
             "start": {
               "line": 135,
               "column": 3,
-              "index": 3129
+              "index": 3135
             },
             "end": {
               "line": 135,
               "column": 19,
-              "index": 3145
+              "index": 3151
             }
           },
           "name": {
@@ -4811,12 +4827,12 @@ snapshot_kind: text
               "start": {
                 "line": 135,
                 "column": 15,
-                "index": 3141
+                "index": 3147
               },
               "end": {
                 "line": 135,
                 "column": 19,
-                "index": 3145
+                "index": 3151
               }
             }
           },
@@ -4827,12 +4843,12 @@ snapshot_kind: text
               "start": {
                 "line": 135,
                 "column": 3,
-                "index": 3129
+                "index": 3135
               },
               "end": {
                 "line": 135,
                 "column": 4,
-                "index": 3130
+                "index": 3136
               }
             }
           },
@@ -4843,12 +4859,12 @@ snapshot_kind: text
               "start": {
                 "line": 135,
                 "column": 6,
-                "index": 3132
+                "index": 3138
               },
               "end": {
                 "line": 135,
                 "column": 12,
-                "index": 3138
+                "index": 3144
               }
             }
           },
@@ -4863,12 +4879,12 @@ snapshot_kind: text
             "start": {
               "line": 136,
               "column": 3,
-              "index": 3197
+              "index": 3203
             },
             "end": {
               "line": 136,
               "column": 13,
-              "index": 3207
+              "index": 3213
             }
           },
           "name": {
@@ -4878,12 +4894,12 @@ snapshot_kind: text
               "start": {
                 "line": 136,
                 "column": 10,
-                "index": 3204
+                "index": 3210
               },
               "end": {
                 "line": 136,
                 "column": 13,
-                "index": 3207
+                "index": 3213
               }
             }
           },
@@ -4894,12 +4910,12 @@ snapshot_kind: text
               "start": {
                 "line": 136,
                 "column": 3,
-                "index": 3197
+                "index": 3203
               },
               "end": {
                 "line": 136,
                 "column": 4,
-                "index": 3198
+                "index": 3204
               }
             }
           },
@@ -4910,12 +4926,12 @@ snapshot_kind: text
               "start": {
                 "line": 136,
                 "column": 6,
-                "index": 3200
+                "index": 3206
               },
               "end": {
                 "line": 136,
                 "column": 9,
-                "index": 3203
+                "index": 3209
               }
             }
           },
@@ -4930,12 +4946,12 @@ snapshot_kind: text
                 "start": {
                   "line": 135,
                   "column": 21,
-                  "index": 3147
+                  "index": 3153
                 },
                 "end": {
                   "line": 135,
                   "column": 68,
-                  "index": 3194
+                  "index": 3200
                 }
               }
             }
@@ -4947,12 +4963,12 @@ snapshot_kind: text
             "start": {
               "line": 137,
               "column": 3,
-              "index": 3211
+              "index": 3217
             },
             "end": {
               "line": 140,
               "column": 28,
-              "index": 3330
+              "index": 3336
             }
           },
           "name": {
@@ -4962,12 +4978,12 @@ snapshot_kind: text
               "start": {
                 "line": 137,
                 "column": 19,
-                "index": 3227
+                "index": 3233
               },
               "end": {
                 "line": 137,
                 "column": 26,
-                "index": 3234
+                "index": 3240
               }
             }
           },
@@ -4978,12 +4994,12 @@ snapshot_kind: text
               "start": {
                 "line": 137,
                 "column": 3,
-                "index": 3211
+                "index": 3217
               },
               "end": {
                 "line": 137,
                 "column": 4,
-                "index": 3212
+                "index": 3218
               }
             }
           },
@@ -4993,12 +5009,12 @@ snapshot_kind: text
               "start": {
                 "line": 137,
                 "column": 6,
-                "index": 3214
+                "index": 3220
               },
               "end": {
                 "line": 137,
                 "column": 18,
-                "index": 3226
+                "index": 3232
               }
             },
             "value": "list",
@@ -5009,12 +5025,12 @@ snapshot_kind: text
                 "start": {
                   "line": 137,
                   "column": 11,
-                  "index": 3219
+                  "index": 3225
                 },
                 "end": {
                   "line": 137,
                   "column": 17,
-                  "index": 3225
+                  "index": 3231
                 }
               }
             }
@@ -5026,12 +5042,12 @@ snapshot_kind: text
               "start": {
                 "line": 137,
                 "column": 29,
-                "index": 3237
+                "index": 3243
               },
               "end": {
                 "line": 140,
                 "column": 28,
-                "index": 3330
+                "index": 3336
               }
             },
             "elements": [
@@ -5042,12 +5058,12 @@ snapshot_kind: text
                   "start": {
                     "line": 139,
                     "column": 5,
-                    "index": 3275
+                    "index": 3281
                   },
                   "end": {
                     "line": 139,
                     "column": 14,
-                    "index": 3284
+                    "index": 3290
                   }
                 }
               },
@@ -5058,12 +5074,12 @@ snapshot_kind: text
                   "start": {
                     "line": 140,
                     "column": 6,
-                    "index": 3308
+                    "index": 3314
                   },
                   "end": {
                     "line": 140,
                     "column": 17,
-                    "index": 3319
+                    "index": 3325
                   }
                 }
               },
@@ -5074,12 +5090,12 @@ snapshot_kind: text
                   "start": {
                     "line": 140,
                     "column": 19,
-                    "index": 3321
+                    "index": 3327
                   },
                   "end": {
                     "line": 140,
                     "column": 27,
-                    "index": 3329
+                    "index": 3335
                   }
                 }
               }
@@ -5097,12 +5113,12 @@ snapshot_kind: text
             "start": {
               "line": 133,
               "column": 1,
-              "index": 3082
+              "index": 3088
             },
             "end": {
               "line": 133,
               "column": 20,
-              "index": 3101
+              "index": 3107
             }
           }
         }

--- a/creates/rico/snapshots/writer/main__snapshots__writer__common.snap
+++ b/creates/rico/snapshots/writer/main__snapshots__writer__common.snap
@@ -12,7 +12,7 @@ namespace cpp mock_example_cpp
 // It can span multiple lines
 // and is useful for providing detailed explanations
 // Include another Thrift file
-include ""common.thrift""
+include "common.thrift"
 
 // Enum definition for user roles
 enum UserRole {
@@ -72,7 +72,7 @@ service AdminService {
   // Method to activate a user
   void activateUser(1: i32 id) throws (1: UserNotFoundException e)
   // Method to get user statistics
-  map<string, i32> getUserStatistics()
+  map<string, list<i32>> getUserStatistics()
 }
 
 // Service definition for NotificationService

--- a/creates/rico/snapshots/writer/main__snapshots__writer__include.snap
+++ b/creates/rico/snapshots/writer/main__snapshots__writer__include.snap
@@ -3,6 +3,6 @@ source: creates/rico/tests/snapshots/writer.rs
 description: Testing include thrift file
 snapshot_kind: text
 ---
-include ""common""
+include "common"
 
-include ""common.a.b""
+include "common.a.b"

--- a/creates/rico/src/ast/definitions.rs
+++ b/creates/rico/src/ast/definitions.rs
@@ -21,9 +21,9 @@ pub struct Comment {
 /// Annotations provide metadata for Thrift definitions and can be used
 /// to customize code generation or add runtime behavior.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always Annotation)
+#[serde(tag = "kind", rename = "Annotation")]
 pub struct Annotation {
-    /// The type of the node (always Annotation)
-    pub kind: NodeType,
     /// The value of the annotation
     pub value: Common<String>,
     /// The location of the annotation in the source code
@@ -36,59 +36,41 @@ pub struct Annotation {
 ///
 /// Multiple annotations can be specified in parentheses after a definition.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always Annotations)
+#[serde(tag = "kind", rename = "Annotations")]
 pub struct Annotations {
-    /// The type of the node (always Annotations)
-    pub kind: NodeType,
     /// The location of the annotations block in the source code
     pub loc: LOC,
     /// The list of individual annotations
     pub members: Vec<Annotation>,
 }
 
-/// Represents a namespace declaration in the Thrift IDL.
+/// Represents a collection type (list or set) in a field definition.
 ///
-/// Namespaces specify the package/module name for generated code in
-/// different target languages.
+/// Collection types can hold multiple values of the same type.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Namespace {
-    /// The type of the node (always NamespaceDefinition)
-    pub kind: NodeType,
-    /// The location of the namespace declaration in the source code
+/// The type of the node (always ListType)
+#[serde(tag = "kind", rename = "ListType")]
+pub struct FieldListType {
+    /// The location in the source code
     pub loc: LOC,
-    /// The namespace identifier
-    pub name: Common<String>,
-    /// The target language scope (e.g., "py", "java", "rs")
-    pub scope: Common<String>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-}
-
-/// Represents an include statement in the Thrift IDL.
-///
-/// Include statements allow splitting Thrift definitions across multiple
-/// files for better organization.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Include {
-    /// The type of the node (always IncludeDefinition)
-    pub kind: NodeType,
-    /// The location of the include statement in the source code
-    pub loc: LOC,
-    /// The name/path of the included file
-    pub name: Common<String>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
+    /// The type name ("list")
+    pub value: String,
+    /// The type of elements in the collection
+    #[serde(rename = "valueType")]
+    pub value_type: Box<FieldType>,
 }
 
 /// Represents a collection type (list or set) in a field definition.
 ///
 /// Collection types can hold multiple values of the same type.
 #[derive(Serialize, Deserialize, Debug)]
-pub struct FieldCollectionType {
-    /// The type of the node (ListType or SetType)
-    pub kind: NodeType,
+/// The type of the node (always SetType)
+#[serde(tag = "kind", rename = "SetType")]
+pub struct FieldSetType {
     /// The location in the source code
     pub loc: LOC,
-    /// The type name ("list" or "set")
+    /// The type name ("set")
     pub value: String,
     /// The type of elements in the collection
     #[serde(rename = "valueType")]
@@ -100,9 +82,9 @@ pub struct FieldCollectionType {
 /// Map types associate keys with values, where both key and value
 /// types can be specified.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always MapType)
+#[serde(tag = "kind", rename = "MapType")]
 pub struct FieldMapType {
-    /// The type of the node (always MapType)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The type name ("map")
@@ -115,31 +97,13 @@ pub struct FieldMapType {
     pub key_type: Box<FieldType>,
 }
 
-/// Represents a field type in the Thrift IDL.
-///
-/// Field types can be:
-/// - Base types (i32, string, etc.)
-/// - Collections (list, set)
-/// - Maps
-/// - User-defined types
-#[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
-pub enum FieldType {
-    /// A collection type (list or set)
-    CollectionType(FieldCollectionType),
-    /// A map type
-    MapType(FieldMapType),
-    /// A base type or user-defined type
-    CommonType(Common<String>),
-}
-
 /// Represents a list of constant values.
 ///
 /// Used for list literals in constant definitions and default values.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always ConstList)
+#[serde(tag = "kind", rename = "ConstList")]
 pub struct ConstList {
-    /// The type of the node (always ConstList)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The list elements
@@ -148,9 +112,9 @@ pub struct ConstList {
 
 /// Represents a key-value pair in a map constant.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always PropertyAssignment)
+#[serde(tag = "kind", rename = "PropertyAssignment")]
 pub struct MapProperty {
-    /// The type of the node (always PropertyAssignment)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The property value
@@ -163,9 +127,9 @@ pub struct MapProperty {
 ///
 /// Used for map literals in constant definitions and default values.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always ConstMap)
+#[serde(tag = "kind", rename = "ConstMap")]
 pub struct ConstMap {
-    /// The type of the node (always ConstMap)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The map entries
@@ -177,52 +141,34 @@ pub struct ConstMap {
 /// Can be a simple value, a list, or a map.
 #[derive(Serialize, Deserialize, Debug)]
 #[serde(untagged)]
+/// enum will deserialize by order,so we should put the most complex type first
 pub enum FieldInitialValue {
-    /// A simple constant value
-    ConstValue(Common<String>),
-    /// A list of values
-    ConstList(ConstList),
     /// A map of key-value pairs
     ConstMap(ConstMap),
+    /// A list of values
+    ConstList(ConstList),
+    /// A simple constant value
+    ConstValue(Common<String>),
 }
 
-/// Represents a constant definition in the Thrift IDL.
+/// Represents a field type in the Thrift IDL.
 ///
-/// Constants can be used to define shared values of any type.
+/// Field types can be:
+/// - Base types (i32, string, etc.)
+/// - Collections (list, set)
+/// - Maps
+/// - User-defined types
 #[derive(Serialize, Deserialize, Debug)]
-pub struct Const {
-    /// The type of the node (always ConstDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The name of the constant
-    pub name: Common<String>,
-    /// The value of the constant
-    pub value: FieldInitialValue,
-    /// The type of the constant
-    #[serde(rename = "fieldType")]
-    pub field_type: FieldType,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-}
-
-/// Represents a typedef definition in the Thrift IDL.
-///
-/// Typedefs create aliases for existing types, which can be used
-/// to provide more meaningful names or documentation.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Typedef {
-    /// The type of the node (always TypedefDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The new type name
-    pub name: Common<String>,
-    /// The original type being aliased
-    #[serde(rename = "fieldType")]
-    pub field_type: FieldType,
-    /// Associated comments
-    pub comments: Vec<Comment>,
+#[serde(untagged)]
+pub enum FieldType {
+    /// A map type
+    MapType(FieldMapType),
+    /// A list type
+    ListType(FieldListType),
+    /// A set type
+    SetType(FieldSetType),
+    /// A base type or user-defined type
+    CommonType(Common<String>),
 }
 
 /// Represents an initializer for an enum value.
@@ -230,7 +176,6 @@ pub struct Typedef {
 /// Enum values can optionally be assigned explicit integer values.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Initializer {
-    /// The type of the node (always Initializer)
     pub kind: NodeType,
     /// The explicit value assigned to the enum member
     pub value: Common<String>,
@@ -242,9 +187,9 @@ pub struct Initializer {
 ///
 /// Each enum member can have an optional explicit value and annotations.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always EnumMember)
+#[serde(tag = "kind", rename = "EnumMember")]
 pub struct EnumMember {
-    /// The type of the node (always EnumMember)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The name of the enum member
@@ -257,32 +202,13 @@ pub struct EnumMember {
     pub annotations: Option<Annotations>,
 }
 
-/// Represents an enum definition in the Thrift IDL.
-///
-/// Enums define a set of named constants that can be used as field types.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Enum {
-    /// The type of the node (always EnumDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The name of the enum
-    pub name: Common<String>,
-    /// The enum members
-    pub members: Vec<EnumMember>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-    /// Optional annotations
-    pub annotations: Option<Annotations>,
-}
-
 /// Represents a field in a struct, union, exception, or function parameter.
 ///
 /// Fields have an optional field ID, type, and various modifiers.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always FieldDefinition)
+#[serde(tag = "kind", rename = "FieldDefinition")]
 pub struct Field {
-    /// The type of the node (always FieldDefinition)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The name of the field
@@ -305,71 +231,13 @@ pub struct Field {
     pub comments: Vec<Comment>,
 }
 
-/// Represents an exception definition in the Thrift IDL.
-///
-/// Exceptions are similar to structs but are used for error handling
-/// in service methods.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Exception {
-    /// The type of the node (always ExceptionDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The name of the exception
-    pub name: Common<String>,
-    /// The fields of the exception
-    pub members: Vec<Field>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-    /// Optional annotations
-    pub annotations: Option<Annotations>,
-}
-
-/// Represents a struct definition in the Thrift IDL.
-///
-/// Structs are the primary way to define complex data types in Thrift.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Struct {
-    /// The type of the node (always StructDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The name of the struct
-    pub name: Common<String>,
-    /// The fields of the struct
-    pub members: Vec<Field>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-    /// Optional annotations
-    pub annotations: Option<Annotations>,
-}
-
-/// Represents a union definition in the Thrift IDL.
-///
-/// Unions are similar to structs but only one field can be set at a time.
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Union {
-    /// The type of the node (always UnionDefinition)
-    pub kind: NodeType,
-    /// The location in the source code
-    pub loc: LOC,
-    /// The name of the union
-    pub name: Common<String>,
-    /// The fields of the union
-    pub members: Vec<Field>,
-    /// Associated comments
-    pub comments: Vec<Comment>,
-    /// Optional annotations
-    pub annotations: Option<Annotations>,
-}
-
 /// Represents a function definition in a service.
 ///
 /// Functions define the methods that can be called on a service.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always FunctionDefinition)
+#[serde(tag = "kind", rename = "FunctionDefinition")]
 pub struct Function {
-    /// The type of the node (always FunctionDefinition)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The name of the function
@@ -389,14 +257,146 @@ pub struct Function {
     pub oneway: bool,
 }
 
+/// Represents a namespace declaration in the Thrift IDL.
+///
+/// Namespaces specify the package/module name for generated code in
+/// different target languages.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Namespace {
+    /// The location of the namespace declaration in the source code
+    pub loc: LOC,
+    /// The namespace identifier
+    pub name: Common<String>,
+    /// The target language scope (e.g., "py", "java", "rs")
+    pub scope: Common<String>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+}
+
+/// Represents an include statement in the Thrift IDL.
+///
+/// Include statements allow splitting Thrift definitions across multiple
+/// files for better organization.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Include {
+    /// The location of the include statement in the source code
+    pub loc: LOC,
+    /// The name/path of the included file
+    pub name: Common<String>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+}
+
+/// Represents a constant definition in the Thrift IDL.
+///
+/// Constants can be used to define shared values of any type.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Const {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The name of the constant
+    pub name: Common<String>,
+    /// The value of the constant
+    pub value: FieldInitialValue,
+    /// The type of the constant
+    #[serde(rename = "fieldType")]
+    pub field_type: FieldType,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+}
+
+/// Represents a typedef definition in the Thrift IDL.
+///
+/// Typedefs create aliases for existing types, which can be used
+/// to provide more meaningful names or documentation.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Typedef {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The new type name
+    pub name: Common<String>,
+    /// The original type being aliased
+    #[serde(rename = "fieldType")]
+    pub field_type: FieldType,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+}
+
+/// Represents an enum definition in the Thrift IDL.
+///
+/// Enums define a set of named constants that can be used as field types.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Enum {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The name of the enum
+    pub name: Common<String>,
+    /// The enum members
+    pub members: Vec<EnumMember>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+    /// Optional annotations
+    pub annotations: Option<Annotations>,
+}
+
+/// Represents an exception definition in the Thrift IDL.
+///
+/// Exceptions are similar to structs but are used for error handling
+/// in service methods.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Exception {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The name of the exception
+    pub name: Common<String>,
+    /// The fields of the exception
+    pub members: Vec<Field>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+    /// Optional annotations
+    pub annotations: Option<Annotations>,
+}
+
+/// Represents a struct definition in the Thrift IDL.
+///
+/// Structs are the primary way to define complex data types in Thrift.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Struct {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The name of the struct
+    pub name: Common<String>,
+    /// The fields of the struct
+    pub members: Vec<Field>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+    /// Optional annotations
+    pub annotations: Option<Annotations>,
+}
+
+/// Represents a union definition in the Thrift IDL.
+///
+/// Unions are similar to structs but only one field can be set at a time.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Union {
+    /// The location in the source code
+    pub loc: LOC,
+    /// The name of the union
+    pub name: Common<String>,
+    /// The fields of the union
+    pub members: Vec<Field>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+    /// Optional annotations
+    pub annotations: Option<Annotations>,
+}
+
 /// Represents a service definition in the Thrift IDL.
 ///
 /// Services define interfaces that can be implemented by servers
 /// and called by clients.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Service {
-    /// The type of the node (always ServiceDefinition)
-    pub kind: NodeType,
     /// The location in the source code
     pub loc: LOC,
     /// The name of the service
@@ -416,9 +416,9 @@ pub struct Service {
 /// A document is the root node of the AST and contains all the
 /// top-level definitions.
 #[derive(Serialize, Deserialize, Debug)]
+/// The type of the node (always ThriftDocument)
+#[serde(tag = "kind", rename = "ThriftDocument")]
 pub struct Document {
-    /// The type of the node (always ThriftDocument)
-    pub kind: NodeType,
     /// The list of top-level definitions
     pub members: Vec<DocumentMembers>,
 }
@@ -428,101 +428,33 @@ pub struct Document {
 /// Each member can be one of several types of definitions that are
 /// allowed at the document level.
 #[derive(Serialize, Deserialize, Debug)]
-#[serde(untagged)]
+#[serde(tag = "kind")]
 pub enum DocumentMembers {
     /// A namespace declaration
+    #[serde(rename = "NamespaceDefinition")]
     Namespace(Namespace),
     /// An include statement
+    #[serde(rename = "IncludeDefinition")]
     Include(Include),
     /// A constant definition
+    #[serde(rename = "ConstDefinition")]
     Const(Const),
     /// A typedef definition
+    #[serde(rename = "TypedefDefinition")]
     Typedef(Typedef),
     /// An enum definition
+    #[serde(rename = "EnumDefinition")]
     Enum(Enum),
     /// A struct definition
+    #[serde(rename = "StructDefinition")]
     Struct(Struct),
     /// A service definition
+    #[serde(rename = "ServiceDefinition")]
     Service(Service),
     /// An exception definition
+    #[serde(rename = "ExceptionDefinition")]
     Exception(Exception),
     /// A union definition
+    #[serde(rename = "UnionDefinition")]
     Union(Union),
-}
-
-impl Document {
-    /// Parse a Document from a JSON string
-    ///
-    /// # Arguments
-    ///
-    /// * `json` - The JSON string to parse
-    ///
-    /// # Returns
-    ///
-    /// * `Result<Document, serde_json::Error>` - The parsed Document or an error
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rico::ast::Document;
-    ///
-    /// let json = r#"{
-    ///     "kind": "ThriftDocument",
-    ///     "members": []
-    /// }"#;
-    ///
-    /// let doc = Document::from_json(json).unwrap();
-    /// ```
-    #[cfg(feature = "json")]
-    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(json)
-    }
-
-    /// Convert the Document to a compact JSON string
-    ///
-    /// # Returns
-    ///
-    /// * `Result<String, serde_json::Error>` - The JSON string or an error
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rico::ast::Document;
-    /// use rico::NodeType;
-    ///
-    /// let doc = Document {
-    ///     kind: NodeType::ThriftDocument,
-    ///     members: vec![]
-    /// };
-    ///
-    /// let json = doc.to_json_compact().unwrap();
-    /// ```
-    #[cfg(feature = "json")]
-    pub fn to_json_compact(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string(self)
-    }
-
-    /// Convert the Document to a pretty-printed JSON string
-    ///
-    /// # Returns
-    ///
-    /// * `Result<String, serde_json::Error>` - The formatted JSON string or an error
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use rico::ast::Document;
-    /// use rico::NodeType;
-    ///
-    /// let doc = Document {
-    ///     kind: NodeType::ThriftDocument,
-    ///     members: vec![]
-    /// };
-    ///
-    /// let json = doc.to_json_pretty().unwrap();
-    /// ```
-    #[cfg(feature = "json")]
-    pub fn to_json_pretty(&self) -> Result<String, serde_json::Error> {
-        serde_json::to_string_pretty(self)
-    }
 }

--- a/creates/rico/src/ast/types.rs
+++ b/creates/rico/src/ast/types.rs
@@ -43,6 +43,7 @@ impl<T> Common<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "PascalCase")]
 pub enum NodeType {
     ThriftDocument,
     ThriftErrors,

--- a/creates/rico/src/parser/definitions.rs
+++ b/creates/rico/src/parser/definitions.rs
@@ -21,7 +21,6 @@ impl<'a> Parser<'a> {
 
         Ok(Include {
             name,
-            kind: NodeType::IncludeDefinition,
             loc: tracker.to_parent_loc(&end_loc),
             comments,
         })
@@ -42,7 +41,6 @@ impl<'a> Parser<'a> {
         let end_loc = name.loc;
 
         Ok(Namespace {
-            kind: NodeType::NamespaceDefinition,
             name,
             scope,
             loc: tracker.to_parent_loc(&end_loc),
@@ -62,7 +60,6 @@ impl<'a> Parser<'a> {
         let const_value = self.parse_field_value()?;
 
         let result = Const {
-            kind: NodeType::ConstDefinition,
             loc: tracker.to_parent_loc(&self.get_token_loc()),
             name,
             value: const_value,
@@ -82,7 +79,6 @@ impl<'a> Parser<'a> {
         let name = create_identifier(self.get_token_loc(), self.text().to_string());
 
         Ok(Typedef {
-            kind: NodeType::TypedefDefinition,
             loc: tracker.to_parent_loc(&name.loc),
             name,
             field_type,
@@ -101,7 +97,6 @@ impl<'a> Parser<'a> {
         let annotations = self.parse_annotations()?;
 
         Ok(Enum {
-            kind: NodeType::EnumDefinition,
             loc: tracker.to_parent_loc(&self.get_token_loc()),
             name,
             members,
@@ -111,45 +106,33 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn parse_struct(&mut self) -> Result<Struct, ParseError> {
-        self.parse_struct_like(
-            NodeType::StructDefinition,
-            |kind, loc, name, members, comments, annotations| Struct {
-                kind,
-                loc,
-                name,
-                members,
-                comments,
-                annotations,
-            },
-        )
+        self.parse_struct_like(|loc, name, members, comments, annotations| Struct {
+            loc,
+            name,
+            members,
+            comments,
+            annotations,
+        })
     }
 
     pub(crate) fn parse_union(&mut self) -> Result<Union, ParseError> {
-        self.parse_struct_like(
-            NodeType::UnionDefinition,
-            |kind, loc, name, members, comments, annotations| Union {
-                kind,
-                loc,
-                name,
-                members,
-                comments,
-                annotations,
-            },
-        )
+        self.parse_struct_like(|loc, name, members, comments, annotations| Union {
+            loc,
+            name,
+            members,
+            comments,
+            annotations,
+        })
     }
 
     pub(crate) fn parse_exception(&mut self) -> Result<Exception, ParseError> {
-        self.parse_struct_like(
-            NodeType::ExceptionDefinition,
-            |kind, loc, name, members, comments, annotations| Exception {
-                kind,
-                loc,
-                name,
-                members,
-                comments,
-                annotations,
-            },
-        )
+        self.parse_struct_like(|loc, name, members, comments, annotations| Exception {
+            loc,
+            name,
+            members,
+            comments,
+            annotations,
+        })
     }
 
     pub(crate) fn parse_annotations(&mut self) -> Result<Option<Annotations>, ParseError> {
@@ -179,7 +162,6 @@ impl<'a> Parser<'a> {
                 };
 
                 annotations.push(Annotation {
-                    kind: NodeType::Annotation,
                     loc: self.get_token_parent_loc(annotation_name.loc.start, value_loc.end),
                     name: annotation_name,
                     value,
@@ -191,7 +173,6 @@ impl<'a> Parser<'a> {
             }
 
             Ok(Some(Annotations {
-                kind: NodeType::Annotations,
                 loc: tracker.to_parent_loc(&self.get_token_loc()),
                 members: annotations,
             }))
@@ -240,7 +221,6 @@ impl<'a> Parser<'a> {
             let function_annotations = parser.parse_annotations()?;
 
             Ok(Function {
-                kind: NodeType::FunctionDefinition,
                 loc: parser.get_token_parent_loc(function_start_loc.start, parser.end_pos()),
                 name: function_name,
                 return_type,
@@ -256,7 +236,6 @@ impl<'a> Parser<'a> {
         let annotations = self.parse_annotations()?;
 
         Ok(Service {
-            kind: NodeType::ServiceDefinition,
             loc: tracker.to_parent_loc(&self.get_token_loc()),
             name,
             extends,
@@ -291,9 +270,7 @@ impl<'a> Parser<'a> {
 
     fn parse_struct_like<T>(
         &mut self,
-        kind: NodeType,
         constructor: impl FnOnce(
-            NodeType,
             LOC,
             Common<String>,
             Vec<Field>,
@@ -313,7 +290,6 @@ impl<'a> Parser<'a> {
         let annotations = self.parse_annotations()?;
 
         Ok(constructor(
-            kind,
             tracker.to_parent_loc(&self.get_token_loc()),
             name,
             members,
@@ -438,7 +414,6 @@ impl<'a> Parser<'a> {
         // Parse annotations if present
         let field_annotations = self.parse_annotations()?;
         Ok(Field {
-            kind: NodeType::FieldDefinition,
             loc: self.get_token_parent_loc(field_start_pos, self.end_pos()),
             field_id,
             name: field_name,

--- a/creates/rico/src/parser/factory.rs
+++ b/creates/rico/src/parser/factory.rs
@@ -2,8 +2,8 @@ use crate::ast::*;
 use crate::lexer::Token;
 
 use super::{
-    Common, ConstList, ConstMap, FieldCollectionType, FieldInitialValue, FieldMapType, FieldType,
-    MapProperty, NodeType, LOC,
+    Common, ConstList, ConstMap, FieldInitialValue, FieldMapType, FieldType, MapProperty, NodeType,
+    LOC,
 };
 
 // for field type
@@ -31,7 +31,6 @@ pub fn create_map_field_type(
     value_type: FieldType,
 ) -> FieldType {
     FieldType::MapType(FieldMapType {
-        kind: NodeType::MapType,
         loc,
         key_type: Box::new(key_type),
         value_type: Box::new(value_type),
@@ -40,8 +39,7 @@ pub fn create_map_field_type(
 }
 
 pub fn create_list_field_type(loc: LOC, slice: &str, value_type: FieldType) -> FieldType {
-    FieldType::CollectionType(FieldCollectionType {
-        kind: NodeType::ListType,
+    FieldType::ListType(FieldListType {
         loc,
         value_type: Box::new(value_type),
         value: slice.to_string(),
@@ -49,8 +47,7 @@ pub fn create_list_field_type(loc: LOC, slice: &str, value_type: FieldType) -> F
 }
 
 pub fn create_set_field_type(loc: LOC, slice: &str, value_type: FieldType) -> FieldType {
-    FieldType::CollectionType(FieldCollectionType {
-        kind: NodeType::SetType,
+    FieldType::SetType(FieldSetType {
         loc,
         value_type: Box::new(value_type),
         value: slice.to_string(),
@@ -76,19 +73,11 @@ pub fn create_identifier_value(loc: LOC, slice: &str) -> FieldInitialValue {
 }
 
 pub fn create_const_list_value(loc: LOC, elements: Vec<FieldInitialValue>) -> FieldInitialValue {
-    FieldInitialValue::ConstList(ConstList {
-        kind: NodeType::ConstList,
-        loc,
-        elements,
-    })
+    FieldInitialValue::ConstList(ConstList { loc, elements })
 }
 
 pub fn create_map_value(loc: LOC, properties: Vec<MapProperty>) -> FieldInitialValue {
-    FieldInitialValue::ConstMap(ConstMap {
-        kind: NodeType::ConstMap,
-        loc,
-        properties,
-    })
+    FieldInitialValue::ConstMap(ConstMap { loc, properties })
 }
 
 pub(crate) fn create_identifier(loc: LOC, value: String) -> Common {
@@ -107,7 +96,6 @@ pub(crate) fn create_enum_member(
     annotations: Option<Annotations>,
 ) -> EnumMember {
     EnumMember {
-        kind: NodeType::EnumMember,
         loc,
         name,
         initializer,

--- a/creates/rico/src/parser/mod.rs
+++ b/creates/rico/src/parser/mod.rs
@@ -211,10 +211,7 @@ impl<'a> Parser<'a> {
             }
         }
 
-        Ok(Document {
-            kind: NodeType::ThriftDocument,
-            members,
-        })
+        Ok(Document { members })
     }
 
     fn create_parser_token(&mut self) -> Option<ParserToken<'a>> {

--- a/creates/rico/src/parser/values.rs
+++ b/creates/rico/src/parser/values.rs
@@ -1,4 +1,4 @@
-use crate::ast::{FieldInitialValue, MapProperty, NodeType};
+use crate::ast::{FieldInitialValue, MapProperty};
 use crate::lexer::Token;
 use crate::parser::error::ParseError;
 use crate::parser::factory::*;
@@ -57,7 +57,6 @@ impl<'a> Parser<'a> {
             let property_value = parser.parse_field_value()?;
 
             Ok(MapProperty {
-                kind: NodeType::PropertyAssignment,
                 loc: parser.get_token_parent_loc(property_start_pos, parser.get_token_loc().end),
                 name: property_key,
                 value: property_value,

--- a/creates/rico/src/writer/document.rs
+++ b/creates/rico/src/writer/document.rs
@@ -25,7 +25,7 @@ impl Writer {
     /// Writes an include statement to the output string.
     pub(crate) fn write_include(&mut self, output: &mut String, inc: &Include) {
         self.write_comments(output, &inc.comments);
-        writeln!(output, "include \"{}\"", inc.name.value).unwrap();
+        writeln!(output, "include {}", inc.name.value).unwrap();
     }
 
     /// Writes a constant definition to the output string.

--- a/creates/rico/src/writer/mod.rs
+++ b/creates/rico/src/writer/mod.rs
@@ -32,10 +32,8 @@ use std::fmt::Write;
 /// ```rust
 /// use rico::writer::Writer;
 /// use rico::ast::Document;
-/// use rico::NodeType;
 ///
 /// let document = Document {
-///     kind: NodeType::ThriftDocument,
 ///     members: vec![]
 /// };
 /// let mut writer = Writer::new();

--- a/creates/rico/src/writer/types.rs
+++ b/creates/rico/src/writer/types.rs
@@ -20,7 +20,12 @@ impl Writer {
     pub(crate) fn write_field_type(&mut self, output: &mut String, field_type: &FieldType) {
         match field_type {
             FieldType::CommonType(t) => write!(output, "{}", t.value).unwrap(),
-            FieldType::CollectionType(t) => {
+            FieldType::ListType(t) => {
+                write!(output, "{}<", t.value).unwrap();
+                self.write_field_type(output, &t.value_type);
+                write!(output, ">").unwrap();
+            }
+            FieldType::SetType(t) => {
                 write!(output, "{}<", t.value).unwrap();
                 self.write_field_type(output, &t.value_type);
                 write!(output, ">").unwrap();

--- a/creates/rico/tests/fixtures/common.thrift
+++ b/creates/rico/tests/fixtures/common.thrift
@@ -74,7 +74,7 @@ service AdminService {
   void activateUser(1: i32 id) throws (1: UserNotFoundException e),
 
   // Method to get user statistics
-  map<string, i32> getUserStatistics()
+  map<string, list<i32>> getUserStatistics()
 }
 
 // Service definition for NotificationService

--- a/wasm/rico/Cargo.toml
+++ b/wasm/rico/Cargo.toml
@@ -15,11 +15,21 @@ publish = false
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["console_error_panic_hook"]
 
 [dependencies]
 rico = { workspace = true }
 wasm-bindgen = "0.2"
 serde-wasm-bindgen = "0.6"
+serde = { workspace = true }
+miette = { workspace = true }
+# The `console_error_panic_hook` crate provides better debugging of panics by
+# logging them with `console.error`. This is great for development, but requires
+# all the `std::fmt` and `std::panicking` infrastructure, so isn't great for
+# code size when deploying.
+console_error_panic_hook = { version = "0.1.7", optional = true }
+
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/wasm/rico/examples/basic.ts
+++ b/wasm/rico/examples/basic.ts
@@ -10,6 +10,7 @@ async function main() {
     struct User {
       1: string name
       2: i32 age
+      3: map<string, list<i32>> getUserStatistics()
     }
   `;
 
@@ -32,7 +33,7 @@ async function main() {
 
     // Write AST back to Thrift IDL
     const output = Rico.write(ast);
-    console.log('Generated Thrift IDL:', output);
+    console.log('Generated Thrift IDL:\n', output);
   } catch (error) {
     console.error('Error:', error);
   }

--- a/wasm/rico/src/error.rs
+++ b/wasm/rico/src/error.rs
@@ -1,0 +1,96 @@
+use std::error::Error;
+
+use miette::{Diagnostic, LabeledSpan};
+use serde::Serialize;
+use wasm_bindgen::prelude::*;
+
+#[derive(Serialize)]
+pub struct Location {
+    line: usize,
+    column: usize,
+    length: usize,
+    source_text: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+pub enum RicoError {
+    #[serde(rename = "ParseError")]
+    Parse {
+        message: String,
+        code: String,
+        help: Option<String>,
+        location: Option<Location>,
+    },
+    #[serde(rename = "SerializationError")]
+    Serialization { message: String, code: String },
+    #[serde(rename = "DeserializationError")]
+    Deserialization { message: String, code: String },
+}
+
+impl RicoError {
+    pub fn serialization(e: impl Error) -> Self {
+        Self::Serialization {
+            message: format!("Failed to serialize AST: {}", e),
+            code: "SERIALIZATION_ERROR".to_string(),
+        }
+    }
+
+    pub fn deserialization(e: impl Error) -> Self {
+        Self::Deserialization {
+            message: format!("Failed to deserialize AST: {}", e),
+            code: "DESERIALIZATION_ERROR".to_string(),
+        }
+    }
+
+    pub fn parse(e: impl Diagnostic, source: &str) -> Self {
+        Self::Parse {
+            message: e.to_string(),
+            code: e
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "PARSE_ERROR".to_string()),
+            help: e.help().map(|s| s.to_string()),
+            location: get_error_location(&e, source),
+        }
+    }
+
+    pub fn to_js_value(&self) -> JsValue {
+        serde_wasm_bindgen::to_value(self).unwrap()
+    }
+}
+
+fn get_error_location(e: &impl Diagnostic, source: &str) -> Option<Location> {
+    e.labels()
+        .into_iter()
+        .flatten()
+        .next()
+        .map(|label: LabeledSpan| calculate_location(label.offset(), label.len(), source))
+}
+
+fn calculate_location(offset: usize, length: usize, source: &str) -> Location {
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Calculate line number and column by counting newlines
+    let mut line = 1;
+    let mut last_newline = 0;
+    let mut pos = 0;
+    for (i, c) in source[..offset].chars().enumerate() {
+        if c == '\n' {
+            line += 1;
+            last_newline = i + 1;
+        }
+        pos = i;
+    }
+    let column = pos - last_newline + 1;
+
+    Location {
+        line,
+        column,
+        length,
+        source_text: lines
+            .get(line - 1)
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
+    }
+}

--- a/wasm/rico/src/index.ts
+++ b/wasm/rico/src/index.ts
@@ -1,5 +1,24 @@
 import init, { Parser, Writer } from './wasm/rico_wasm';
-import type { Document } from './types';
+import type { Document, ParseError } from './types';
+
+export class RicoError extends Error {
+  constructor(public details: ParseError) {
+    const message = [
+      `${details.message}${
+        details.location &&
+        `(${details.location.line}:${details.location.column})`
+      }`,
+      details.help && `Help: ${details.help}`
+    ]
+      .filter(Boolean)
+      .join('\n');
+
+    super(message);
+    this.name = 'RicoError';
+    // Prevent V8 from collecting stack trace
+    Error.captureStackTrace(this, RicoError);
+  }
+}
 
 export class Rico {
   private static initialized = false;
@@ -16,7 +35,14 @@ export class Rico {
       throw new Error('Rico is not initialized. Call Rico.initialize() first.');
     }
     const parser = new Parser(input);
-    return parser.parse() as Promise<Document>;
+    try {
+      return parser.parse();
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'kind' in error) {
+        throw new RicoError(error as ParseError);
+      }
+      throw error;
+    }
   }
 
   static write(ast: Document): string {
@@ -24,7 +50,14 @@ export class Rico {
       throw new Error('Rico is not initialized. Call Rico.initialize() first.');
     }
     const writer = new Writer();
-    return writer.write(ast);
+    try {
+      return writer.write(ast);
+    } catch (error) {
+      if (typeof error === 'object' && error !== null && 'kind' in error) {
+        throw new RicoError(error as ParseError);
+      }
+      throw error;
+    }
   }
 }
 

--- a/wasm/rico/src/lib.rs
+++ b/wasm/rico/src/lib.rs
@@ -1,3 +1,4 @@
+mod error;
 mod utils;
 mod wasm;
 

--- a/wasm/rico/src/lib.rs
+++ b/wasm/rico/src/lib.rs
@@ -1,3 +1,4 @@
+mod utils;
 mod wasm;
 
 pub use wasm::*;

--- a/wasm/rico/src/types.ts
+++ b/wasm/rico/src/types.ts
@@ -210,3 +210,16 @@ export type FieldValue =
   | Common<string | number | boolean>
   | ConstList
   | ConstMap;
+
+export interface ParseError {
+  kind: 'ParseError' | 'SerializationError' | 'DeserializationError';
+  message: string;
+  code: string;
+  help?: string;
+  location?: {
+    line: number;
+    column: number;
+    length: number;
+    sourceText: string;
+  };
+}

--- a/wasm/rico/src/utils.rs
+++ b/wasm/rico/src/utils.rs
@@ -1,0 +1,11 @@
+pub fn set_panic_hook() {
+    // When the `console_error_panic_hook` feature is enabled, we can call the
+    // `set_panic_hook` function at least once during initialization, and then
+    // we will get better error messages if our code ever panics.
+    //
+    // For more details see
+    // https://github.com/rustwasm/console_error_panic_hook#readme
+    #[cfg(feature = "console_error_panic_hook")]
+    console_error_panic_hook::set_once();
+}
+

--- a/wasm/rico/src/wasm.rs
+++ b/wasm/rico/src/wasm.rs
@@ -1,102 +1,8 @@
-use std::error::Error;
-
-use miette::{Diagnostic, LabeledSpan};
 use rico::{Parser as RicoParser, Writer as RicoWriter};
-use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
+use crate::error::RicoError;
 use crate::utils::set_panic_hook;
-
-#[derive(Serialize)]
-struct Location {
-    line: usize,
-    column: usize,
-    length: usize,
-    source_text: String,
-}
-
-#[derive(Serialize)]
-#[serde(tag = "kind")]
-enum RicoError {
-    #[serde(rename = "ParseError")]
-    Parse {
-        message: String,
-        code: String,
-        help: Option<String>,
-        location: Option<Location>,
-    },
-    #[serde(rename = "SerializationError")]
-    Serialization { message: String, code: String },
-    #[serde(rename = "DeserializationError")]
-    Deserialization { message: String, code: String },
-}
-
-impl RicoError {
-    fn serialization(e: impl Error) -> Self {
-        Self::Serialization {
-            message: format!("Failed to serialize AST: {}", e),
-            code: "SERIALIZATION_ERROR".to_string(),
-        }
-    }
-
-    fn deserialization(e: impl Error) -> Self {
-        Self::Deserialization {
-            message: format!("Failed to deserialize AST: {}", e),
-            code: "DESERIALIZATION_ERROR".to_string(),
-        }
-    }
-
-    fn parse(e: impl Diagnostic, source: &str) -> Self {
-        Self::Parse {
-            message: e.to_string(),
-            code: e
-                .code()
-                .map(|c| c.to_string())
-                .unwrap_or_else(|| "PARSE_ERROR".to_string()),
-            help: e.help().map(|s| s.to_string()),
-            location: get_error_location(&e, source),
-        }
-    }
-
-    fn to_js_value(&self) -> JsValue {
-        serde_wasm_bindgen::to_value(self).unwrap()
-    }
-}
-
-fn get_error_location(e: &impl Diagnostic, source: &str) -> Option<Location> {
-    e.labels()
-        .into_iter()
-        .flatten()
-        .next()
-        .map(|label: LabeledSpan| calculate_location(label.offset(), label.len(), source))
-}
-
-fn calculate_location(offset: usize, length: usize, source: &str) -> Location {
-    let lines: Vec<&str> = source.lines().collect();
-
-    // Calculate line number and column by counting newlines
-    let mut line = 1;
-    let mut last_newline = 0;
-    let mut pos = 0;
-    for (i, c) in source[..offset].chars().enumerate() {
-        if c == '\n' {
-            line += 1;
-            last_newline = i + 1;
-        }
-        pos = i;
-    }
-    let column = pos - last_newline + 1;
-
-    Location {
-        line,
-        column,
-        length,
-        source_text: lines
-            .get(line - 1)
-            .map(|s| s.to_string())
-            .unwrap_or_default(),
-    }
-}
 
 #[wasm_bindgen]
 pub struct Parser {
@@ -139,8 +45,9 @@ impl Writer {
 
     #[wasm_bindgen]
     pub fn write(&mut self, ast: JsValue) -> Result<String, JsValue> {
-        let ast = serde_wasm_bindgen::from_value(ast)
+        let ast: rico::Document = serde_wasm_bindgen::from_value(ast)
             .map_err(|e| RicoError::deserialization(e).to_js_value())?;
+
         Ok(self.inner.write(&ast))
     }
 }

--- a/wasm/rico/src/wasm.rs
+++ b/wasm/rico/src/wasm.rs
@@ -1,5 +1,102 @@
+use std::error::Error;
+
+use miette::{Diagnostic, LabeledSpan};
 use rico::{Parser as RicoParser, Writer as RicoWriter};
+use serde::Serialize;
 use wasm_bindgen::prelude::*;
+
+use crate::utils::set_panic_hook;
+
+#[derive(Serialize)]
+struct Location {
+    line: usize,
+    column: usize,
+    length: usize,
+    source_text: String,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+enum RicoError {
+    #[serde(rename = "ParseError")]
+    Parse {
+        message: String,
+        code: String,
+        help: Option<String>,
+        location: Option<Location>,
+    },
+    #[serde(rename = "SerializationError")]
+    Serialization { message: String, code: String },
+    #[serde(rename = "DeserializationError")]
+    Deserialization { message: String, code: String },
+}
+
+impl RicoError {
+    fn serialization(e: impl Error) -> Self {
+        Self::Serialization {
+            message: format!("Failed to serialize AST: {}", e),
+            code: "SERIALIZATION_ERROR".to_string(),
+        }
+    }
+
+    fn deserialization(e: impl Error) -> Self {
+        Self::Deserialization {
+            message: format!("Failed to deserialize AST: {}", e),
+            code: "DESERIALIZATION_ERROR".to_string(),
+        }
+    }
+
+    fn parse(e: impl Diagnostic, source: &str) -> Self {
+        Self::Parse {
+            message: e.to_string(),
+            code: e
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "PARSE_ERROR".to_string()),
+            help: e.help().map(|s| s.to_string()),
+            location: get_error_location(&e, source),
+        }
+    }
+
+    fn to_js_value(&self) -> JsValue {
+        serde_wasm_bindgen::to_value(self).unwrap()
+    }
+}
+
+fn get_error_location(e: &impl Diagnostic, source: &str) -> Option<Location> {
+    e.labels()
+        .into_iter()
+        .flatten()
+        .next()
+        .map(|label: LabeledSpan| calculate_location(label.offset(), label.len(), source))
+}
+
+fn calculate_location(offset: usize, length: usize, source: &str) -> Location {
+    let lines: Vec<&str> = source.lines().collect();
+
+    // Calculate line number and column by counting newlines
+    let mut line = 1;
+    let mut last_newline = 0;
+    let mut pos = 0;
+    for (i, c) in source[..offset].chars().enumerate() {
+        if c == '\n' {
+            line += 1;
+            last_newline = i + 1;
+        }
+        pos = i;
+    }
+    let column = pos - last_newline + 1;
+
+    Location {
+        line,
+        column,
+        length,
+        source_text: lines
+            .get(line - 1)
+            .map(|s| s.to_string())
+            .unwrap_or_default(),
+    }
+}
 
 #[wasm_bindgen]
 pub struct Parser {
@@ -10,16 +107,17 @@ pub struct Parser {
 impl Parser {
     #[wasm_bindgen(constructor)]
     pub fn new(input: String) -> Self {
+        set_panic_hook();
         Self { input }
     }
 
     #[wasm_bindgen]
-    pub fn parse(&mut self) -> Result<JsValue, JsError> {
+    pub fn parse(&mut self) -> Result<JsValue, JsValue> {
         let mut parser = RicoParser::new(&self.input);
         match parser.parse() {
             Ok(ast) => serde_wasm_bindgen::to_value(&ast)
-                .map_err(|e| JsError::new(&format!("Failed to serialize AST: {}", e))),
-            Err(e) => Err(JsError::new(&format!("Parse error: {}", e))),
+                .map_err(|e| RicoError::serialization(e).to_js_value()),
+            Err(e) => Err(RicoError::parse(e, &self.input).to_js_value()),
         }
     }
 }
@@ -33,15 +131,16 @@ pub struct Writer {
 impl Writer {
     #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
+        set_panic_hook();
         Self {
             inner: RicoWriter::new(),
         }
     }
 
     #[wasm_bindgen]
-    pub fn write(&mut self, ast: JsValue) -> Result<String, JsError> {
+    pub fn write(&mut self, ast: JsValue) -> Result<String, JsValue> {
         let ast = serde_wasm_bindgen::from_value(ast)
-            .map_err(|e| JsError::new(&format!("Failed to deserialize AST: {}", e)))?;
+            .map_err(|e| RicoError::deserialization(e).to_js_value())?;
         Ok(self.inner.write(&ast))
     }
 }


### PR DESCRIPTION
In the process of deserializing from json to rust structure, unclear enum tags or order will lead to structure mapping errors. For details, please refer to serd's parsing rules [enum-representations](https://serde.rs/enum-representations.html.) 

In this adjustment In , `kind` is used as the field output by `serd`, and the definition of the original structure is cancelled. For enum structures without the kind annotation, the parsing order has been readjusted.
```rust
// befor
#[derive(Serialize, Deserialize, Debug)]
#[serde(untagged)]
pub enum DocumentMembers {
    /// A namespace declaration
    Namespace(Namespace),
}

// after
#[derive(Serialize, Deserialize, Debug)]
#[serde(tag = "kind")]
pub enum DocumentMembers {
    /// A namespace declaration
    #[serde(rename = "NamespaceDefinition")]
    Namespace(Namespace),
}
```

In addition, the error performance of wasm has also been optimized to make errors more readable.