### PR TITLE
Improve Thrift parser coverage and WASM API

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A high-performance Apache Thrift IDL parser written in Rust that converts Thrift
 ## Features
 
 - 🚀 Fast and efficient parsing
-- 🎯 Complete Thrift IDL support
+- 🎯 Practical Thrift IDL support with a stable JSON AST
 - 🔄 JSON AST output
 - 📝 Comment preservation
 - 🎨 Detailed source location tracking
@@ -98,18 +98,29 @@ cargo run -p benchmark
 - `apps/scan/`: CLI tool for batch processing
 - `apps/benchmark/`: Performance benchmarking tool
 
-## Supported Thrift Features
+## Supported Thrift Syntax
 
-- Base types (i32, i64, string, etc.)
-- Collections (list, set, map)
-- Structs and Exceptions
-- Services and Functions
-- Enums
-- Constants
-- Typedefs
-- Namespaces
-- Includes
-- Comments and Annotations
+Rico focuses on the mainstream Thrift IDL surface used by JS and Rust tooling while keeping the JSON `Document` AST stable.
+
+### Types
+
+- Base types: `bool`, `byte`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
+- Identifier types: user-defined structs, enums, exceptions, unions, typedefs, and qualified names such as `shared.User`
+- Containers: `list<T>`, `set<T>`, `map<K, V>`, including nested containers
+
+### Definitions
+
+- Headers: `include`, `cpp_include`, `namespace`, and `namespace *`
+- `const`, `typedef`, `enum`, `struct`, `union`, `exception`, `service`
+- Service `extends`, `throws`, and `oneway`
+- Field ids, `required`, `optional`, and default-required fields
+- Const/default values: strings, integers, hex integers, doubles, scientific notation, booleans, identifiers, lists, and maps
+- Annotations on fields, enum members, definitions, functions, and services
+- Comments: `//`, `#`, and `/* ... */`
+
+### Intentional Non-Goals
+
+Rare or legacy Thrift extensions are not currently parsed, including `senum`, `uuid`, container `cpp_type`, and XSD-specific options such as `xsd_all`, `xsd_optional`, `xsd_nillable`, and `xsd_attrs`. Keeping these out preserves a smaller parser surface and a stable AST for JS ecosystem consumers.
 
 ## Development
 

--- a/apps/benchmark/benches/fixtures/large.thrift
+++ b/apps/benchmark/benches/fixtures/large.thrift
@@ -1,212 +1,142 @@
-// help me generate thrift code according to Apache Thrift IDL syntax
+// Rico benchmark fixture: broad Apache Thrift IDL syntax coverage.
+/* Header block comment spanning
+ * multiple lines to verify location tracking.
+ */
+cpp_include "generated/rico_types.h";
+include "shared/common.thrift";
 
-namespace py mock_example
-namespace cpp mock_example_cpp
+namespace * rico.fixtures;
+namespace rs rico.fixtures.rs
+namespace cpp2 rico.fixtures.cpp2
+namespace py rico.fixtures.py
 
-// This is a multi-line comment
-// It can span multiple lines
-// and is useful for providing detailed explanations
+# Type aliases
+typedef i64 UserId;
+typedef map<string, list<i32>> ScoreBuckets
+typedef set<string> StringSet
 
-// Include another Thrift file
-include "common.thrift"
+// Primitive constants
+const bool CONST_BOOL_TRUE = true
+const bool CONST_BOOL_FALSE = false
+const byte CONST_BYTE = 7
+const i8 CONST_I8 = -8
+const i16 CONST_I16 = -16
+const i32 CONST_I32 = 2147483647
+const i64 CONST_I64 = 9223372036854775807
+const double CONST_DOUBLE = -42.125
+const double CONST_EXP = 6.02e23
+const double CONST_FRACTION = .5
+const string CONST_STRING = "escaped \"quote\" and slash \\"
+const binary CONST_BINARY = 'raw-bytes'
+const i32 CONST_HEX = 0x2A
+const i32 CONST_REF = CONST_I32
 
-// Enum definition for user roles
-enum UserRole {
-  ADMIN = 1,
-  USER = 2,
-  GUEST = 3
+const list<string> CONST_LIST = [
+  // Value comments should not become comments on later definitions.
+  "alpha",
+  # Hash comments inside values are trivia.
+  "beta";
+  /* Block comments inside values are trivia. */
+  "gamma",
+]
+
+const map<string, list<i32>> CONST_MAP = {
+  "one": [1, 2, 3],
+  // Comment between map properties.
+  "two": [
+    4;
+    5,
+    6,
+  ],
 }
 
-// Enum definition for user status
-enum UserStatus {
-    INACTIVE = 0,
-    ACTIVE = 1,
-    SUSPENDED = 2,
-    BANNED = 3
+enum Lifecycle {
+  UNKNOWN = 0,
+  ACTIVE = 1 (description = "currently active"),
+  DISABLED = 2;
+  DELETED = 0x03
+} (
+  // Annotation comments are trivia.
+  rust.exhaustive = "false";
+  owner = "rico"
+);
+
+enum SignedEnum {
+  NEGATIVE = -1
+  ZERO = 0
+  POSITIVE = 1
 }
 
-// Enum definition for access levels
-enum AccessLevel {
-    GUEST_ACCESS = 1,
-    READ_ONLY_ACCESS = 2,
-    READ_WRITE_ACCESS = 3,
-    ADMIN_ACCESS = 4
+struct EmptyStruct {
+};
+
+// All primitive and container field forms.
+struct PrimitiveBag {
+  1: required bool bool_value = true (js.name = "boolValue"),
+  2: optional byte byte_value = 1,
+  3: optional i8 i8_value = -8,
+  4: optional i16 i16_value = -16,
+  5: optional i32 i32_value = 32,
+  6: optional i64 i64_value = 64,
+  7: optional double double_value = 1.25,
+  8: optional string string_value = "hello",
+  9: optional binary binary_value = "bytes",
+  10: optional list<string> list_value = [
+    "first",
+    "second",
+  ],
+  11: optional set<i32> set_value,
+  12: optional map<string, list<set<i32>>> nested_value,
+  13: Lifecycle lifecycle = ACTIVE,
+  // Leading comment for the next field must stay attached to that field.
+  14: optional string commented_field,
+} (table = "primitive_bag")
+
+struct CommentStress {
+  1: list<string> values = [
+    "first",
+    // This value comment must be discarded.
+    "second",
+  ],
+  2: string after_values,
+  # Hash comment before field three.
+  3: optional map<string, string> metadata = {
+    "left": "right",
+    /* Block value comment must be discarded. */
+    "up": "down",
+  },
+};
+
+union SearchKey {
+  1: UserId user_id,
+  2: string email,
+  3: binary digest,
+} (serde = "untagged")
+
+exception ValidationError {
+  1: required string message,
+  2: optional map<string, string> details,
+} (retryable = "false");
+
+service BaseService {
+  void ping();
 }
 
-// Enum definition for log levels
-enum LogLevel {
-    DEBUG = 1
-    INFO = 2
-    WARN = 3
-    ERROR = 4
-    FATAL = 5
-}
+service UserService extends BaseService {
+  // Fetch with comments inside the parameter list.
+  PrimitiveBag get_user(
+    1: required UserId id,
+    // Parameter leading comment.
+    2: optional string request_id,
+  ) throws (
+    1: ValidationError validation_error,
+  ) (route = "/users/{id}")
 
-// Union type for a value that can be either an integer or a string
-union IntOrString {
-    1: i32 int_value
-    2: string string_value
-}
+  oneway void publish_event(1: string topic, 2: binary payload)
 
-// Union type for a result that can be a user object, an error message, or a boolean indicating success
-union UserResult {
-    1: User user_data
-    2: string error_message
-    3: bool success
-}
-
-// Union type for a configuration option that can be an integer, a string, or a list of strings
-union ConfigOption {
-    1: i32 int_setting
-    2: string string_setting
-    3: list<string> string_list_setting
-}
-
-// Union type for a data container that can hold different types of data related to an item
-union ItemData {
-    1: i32 item_id
-    2: string item_name
-    3: map<string, i32> item_attributes
-    4: list<ItemDetail> item_details
-}
-
-// Constant of integer type representing the default port number
-const i32 DEFAULT_PORT = 8080
-
-// Constant of string type for the default hostname
-const string DEFAULT_HOSTNAME = "localhost"
-
-// Constant of boolean type indicating if the application is in debug mode
-const bool IS_DEBUG_MODE = false
-
-// Constant of list<string> type with some default usernames
-const list<string> DEFAULT_USERNAMES = ["user1", "user2", "user3"]
-
-// Constant of map<string, i32> type mapping department names to their respective ID numbers
-const map<string, i32> DEPARTMENT_IDS = {
-    "Engineering": 1001,
-    "Marketing": 1002,
-    "Sales": 1003
-}
-// Struct definition for User
-struct User {
-  1: i32 id,
-  2: string name,
-  3: string email,
-  4: UserStatus status,
-  5: UserRole role
-}
-
-// Nested struct definition for Address
-struct Address {
-  1: string street,
-  2: string city,
-  3: string state,
-  4: string zip
-}
-
-// Struct with default values for UserProfile
-struct UserProfile {
-  1: User user,
-  2: Address address,
-  3: list<string> hobbies = [],
-  4: map<string, string> preferences = {}
-}
-
-// Exception definition for user not found
-exception UserNotFoundException {
-  1: string message
-}
-
-// Service definition for UserService
-service UserService {
-  // Method to get a user by ID
-  User getUser(1: i32 id) throws (1: UserNotFoundException e),
-
-  // Method to save a user
-  void saveUser(1: User user),
-
-  // Method to delete a user
-  void deleteUser(1: i32 id) throws (1: UserNotFoundException e),
-
-  // Method to list all users
-  list<User> listUsers(),
-
-  // Method to update user profile
-  void updateUserProfile(1: UserProfile profile) throws (1: UserNotFoundException e)
-}
-
-// Service definition for AdminService
-service AdminService {
-  // Method to suspend a user
-  void suspendUser(1: i32 id) throws (1: UserNotFoundException e),
-
-  // Method to activate a user
-  void activateUser(1: i32 id) throws (1: UserNotFoundException e),
-
-  // Method to get user statistics
-  map<string, i32> getUserStatistics()
-}
-
-// Service definition for NotificationService
-service NotificationService {
-  // Method to send a notification
-  void sendNotification(1: string message, 2: list<i32> userIds),
-
-  // Method to get notifications for a user
-  list<string> getUserNotifications(1: i32 userId)
-}
-
-// The following are examples of irregular writing
-
-// Inconsistent indentation
-struct InconsistentIndentation {
-  1: i32 id,
-    2: string name, // The indentation of this field is inconsistent
-  3: string email
-}
-
-// Duplicate field names
-struct DuplicateFieldNames {
-  1: string name,
-  2: string name, // This field name is duplicated
-  3: i32 age
-}
-
-// Missing necessary fields
-struct IncompleteUser {
-  1: i32 id,
-  // 2: string name, // This field is missing
-  3: string email
-}
-
-// Irregular comment style
-// This is a comment without a clear purpose
-// This line of comment doesn't provide useful information
-struct UnclearComment {
-  1: string data // The comment for this field is not clear
-}
-
-// Extra blank lines
-struct ExtraEmptyLines {
-
-  1: string info
-
-
-  // There are redundant blank lines in this struct
-}
-
-// Long line
-struct LongLineExample {
-  1: string description = "This is a very long line that exceeds the typical length for a single line in Thrift IDL and should be broken up for better readability."
-}
-
-// Excessive spaces
-struct ExcessiveSpaces {
-  1: string   name, // There are excessive spaces before this field
-  2: i32 age,
-  3: list<string> hobbies = [
-    # Another irregular writing
-    "reading", // Value comment
-     "traveling", "coding"]
-}
+  map<string, list<PrimitiveBag>> search(
+    1: SearchKey key;
+    2: ScoreBuckets scores,
+    3: StringSet tags = [],
+  )
+} (service.version = "1")

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.36.1",
     "@radix-ui/react-slot": "^1.1.1",
-    "@rico-core/parser": "workspace:*",
+    "@rico-core/parser": "^0.0.5",
     "@uiw/codemirror-theme-github": "^4.23.7",
     "@uiw/react-codemirror": "^4.23.6",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "@codemirror/state": "^6.5.0",
     "@codemirror/view": "^6.36.1",
     "@radix-ui/react-slot": "^1.1.1",
-    "@rico-core/parser": "0.0.3",
+    "@rico-core/parser": "workspace:*",
     "@uiw/codemirror-theme-github": "^4.23.7",
     "@uiw/react-codemirror": "^4.23.6",
     "class-variance-authority": "^0.7.1",

--- a/creates/rico/README.md
+++ b/creates/rico/README.md
@@ -5,7 +5,7 @@ A high-performance Apache Thrift IDL parser written in Rust that converts Thrift
 ## Features
 
 - 🚀 Fast and efficient parsing
-- 🎯 Complete Thrift IDL support
+- 🎯 Practical Thrift IDL support with a stable JSON AST
 - 🔄 JSON AST output
 - 📝 Comment preservation
 - 🎨 Detailed source location tracking
@@ -44,18 +44,29 @@ fn main() {
 }
 ```
 
-## Supported Thrift Features
+## Supported Thrift Syntax
 
-- Base types (i32, i64, string, etc.)
-- Collections (list, set, map)
-- Structs and Exceptions
-- Services and Functions
-- Enums
-- Constants
-- Typedefs
-- Namespaces
-- Includes
-- Comments and Annotations
+Rico focuses on the mainstream Thrift IDL surface used by JS and Rust tooling while keeping the JSON `Document` AST stable.
+
+### Types
+
+- Base types: `bool`, `byte`, `i8`, `i16`, `i32`, `i64`, `double`, `string`, `binary`
+- Identifier types: user-defined structs, enums, exceptions, unions, typedefs, and qualified names such as `shared.User`
+- Containers: `list<T>`, `set<T>`, `map<K, V>`, including nested containers
+
+### Definitions
+
+- Headers: `include`, `cpp_include`, `namespace`, and `namespace *`
+- `const`, `typedef`, `enum`, `struct`, `union`, `exception`, `service`
+- Service `extends`, `throws`, and `oneway`
+- Field ids, `required`, `optional`, and default-required fields
+- Const/default values: strings, integers, hex integers, doubles, scientific notation, booleans, identifiers, lists, and maps
+- Annotations on fields, enum members, definitions, functions, and services
+- Comments: `//`, `#`, and `/* ... */`
+
+### Intentional Non-Goals
+
+Rare or legacy Thrift extensions are not currently parsed, including `senum`, `uuid`, container `cpp_type`, and XSD-specific options such as `xsd_all`, `xsd_optional`, `xsd_nillable`, and `xsd_attrs`. Keeping these out preserves a smaller parser surface and a stable AST for JS ecosystem consumers.
 
 ## Development
 

--- a/creates/rico/src/ast/definitions.rs
+++ b/creates/rico/src/ast/definitions.rs
@@ -287,6 +287,17 @@ pub struct Include {
     pub comments: Vec<Comment>,
 }
 
+/// Represents a C++ include statement in the Thrift IDL.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct CppInclude {
+    /// The location of the cpp_include declaration in the source code
+    pub loc: LOC,
+    /// The name/path of the included C++ header
+    pub name: Common<String>,
+    /// Associated comments
+    pub comments: Vec<Comment>,
+}
+
 /// Represents a constant definition in the Thrift IDL.
 ///
 /// Constants can be used to define shared values of any type.
@@ -436,6 +447,9 @@ pub enum DocumentMembers {
     /// An include statement
     #[serde(rename = "IncludeDefinition")]
     Include(Include),
+    /// A C++ include statement
+    #[serde(rename = "CppIncludeDefinition")]
+    CppInclude(CppInclude),
     /// A constant definition
     #[serde(rename = "ConstDefinition")]
     Const(Const),

--- a/creates/rico/src/ast/types.rs
+++ b/creates/rico/src/ast/types.rs
@@ -141,6 +141,7 @@ impl NodeType {
             // Keywords
             Token::Namespace => Some(NodeType::NamespaceKeyword),
             Token::Include => Some(NodeType::IncludeKeyword),
+            Token::CppInclude => Some(NodeType::CppIncludeKeyword),
             Token::Exception => Some(NodeType::ExceptionKeyword),
             Token::Service => Some(NodeType::ServiceKeyword),
             Token::Extends => Some(NodeType::ExtendsKeyword),
@@ -155,6 +156,7 @@ impl NodeType {
             Token::Binary => Some(NodeType::BinaryKeyword),
             Token::Bool => Some(NodeType::BoolKeyword),
             Token::Byte => Some(NodeType::ByteKeyword),
+            Token::I8 => Some(NodeType::I8Keyword),
             Token::Enum => Some(NodeType::EnumKeyword),
             Token::List => Some(NodeType::ListKeyword),
             Token::Set => Some(NodeType::SetKeyword),

--- a/creates/rico/src/lexer/token.rs
+++ b/creates/rico/src/lexer/token.rs
@@ -7,7 +7,7 @@ fn newline_callback(lex: &mut Lexer<Token>) -> Skip {
     Skip
 }
 
-#[derive(Logos, Debug, PartialEq, Clone)]
+#[derive(Logos, Debug, PartialEq, Clone, Copy)]
 #[logos(skip r"[ \t]+")]
 #[logos(extras = (usize, usize))]
 pub enum Token {
@@ -17,6 +17,8 @@ pub enum Token {
     // Keywords
     #[token("namespace")]
     Namespace,
+    #[token("cpp_include")]
+    CppInclude,
     #[token("include")]
     Include,
     #[token("typedef")]
@@ -49,6 +51,8 @@ pub enum Token {
     Bool,
     #[token("byte")]
     Byte,
+    #[token("i8")]
+    I8,
     #[token("i16")]
     I16,
     #[token("i32")]
@@ -74,18 +78,18 @@ pub enum Token {
     #[regex(r#"(?:"([^"\\]|\\.)*"|'([^'\\]|\\.)*')"#)]
     StringLiteral,
 
+    #[regex(r"[+-]?(?:(?:[0-9]+\.[0-9]*|\.[0-9]+)(?:[eE][-+]?[0-9]+)?|[0-9]+[eE][-+]?[0-9]+)")]
+    DoubleLiteral,
+
+    #[regex(r"0[xX][0-9a-fA-F]+")]
+    HexLiteral,
+
     #[regex(r"[+-]?[0-9]+")]
     IntegerLiteral,
-
-    #[regex(r"[+-]?[0-9]*\.[0-9]+([eE][-+]?[0-9]+)?")]
-    DoubleLiteral,
 
     #[token("true")]
     #[token("false")]
     BooleanLiteral,
-
-    #[regex(r"0[xX][0-9a-fA-F]+")]
-    HexLiteral,
 
     // Punctuation
     #[token("{")]
@@ -114,6 +118,8 @@ pub enum Token {
     Equals,
     #[token(".")]
     Dot,
+    #[token("*")]
+    Star,
 
     // Comments
     #[regex(r"(//|#).*")]

--- a/creates/rico/src/parser/definitions.rs
+++ b/creates/rico/src/parser/definitions.rs
@@ -26,11 +26,32 @@ impl<'a> Parser<'a> {
         })
     }
 
+    pub(crate) fn parse_cpp_include(&mut self) -> Result<CppInclude, ParseError> {
+        let tracker = LocationTracker::new(self.start_pos());
+        let comments = self.take_pending_comments();
+
+        self.consume_with_error(
+            Token::StringLiteral,
+            ParseErrorKind::MissingIncludeIdentifier,
+        )?;
+        let name = create_identifier(self.get_token_loc(), self.text().to_string());
+        let end_loc = name.loc;
+
+        Ok(CppInclude {
+            name,
+            loc: tracker.to_parent_loc(&end_loc),
+            comments,
+        })
+    }
+
     pub(crate) fn parse_namespace(&mut self) -> Result<Namespace, ParseError> {
         let tracker = LocationTracker::new(self.start_pos());
         let comments = self.take_pending_comments();
 
-        self.consume_with_error(Token::Identifier, ParseErrorKind::MissingNamespaceScope)?;
+        self.advance();
+        if !matches!(self.token(), Some(Token::Identifier | Token::Star)) {
+            return Err(self.error(ParseErrorKind::MissingNamespaceScope));
+        }
         let scope = create_identifier(self.get_token_loc(), self.text().to_owned());
 
         self.consume_with_error(
@@ -136,7 +157,7 @@ impl<'a> Parser<'a> {
     }
 
     pub(crate) fn parse_annotations(&mut self) -> Result<Option<Annotations>, ParseError> {
-        let mut annotations = Vec::new();
+        let mut annotations = Vec::with_capacity(2);
 
         if let Some(Token::LeftParen) = self.peek() {
             let tracker = LocationTracker::new(self.start_pos());
@@ -144,6 +165,7 @@ impl<'a> Parser<'a> {
 
             loop {
                 self.advance();
+                self.skip_comments_discard();
                 if let Some(Token::RightParen) = self.token() {
                     break;
                 }
@@ -167,7 +189,7 @@ impl<'a> Parser<'a> {
                     value,
                 });
 
-                if let Some(Token::Comma) = self.peek() {
+                if matches!(self.peek(), Some(Token::Comma | Token::Semicolon)) {
                     self.advance();
                 }
             }
@@ -346,27 +368,37 @@ impl<'a> Parser<'a> {
     fn parse_field_name(&mut self) -> Result<Common<String>, ParseError> {
         self.advance();
 
-        const VALID_TOKENS: &[Token] = &[
-            Token::Identifier,
-            // adapt keywords, but not recommend to use
-            Token::Namespace,
-            Token::Include,
-            Token::List,
-            Token::Map,
-            Token::Set,
-            Token::Oneway,
-            Token::Required,
-            Token::Optional,
-            Token::Throws,
-            Token::Bool,
-            Token::Extends,
-            Token::Struct,
-            Token::Double,
-            Token::Service,
-            Token::Enum,
-        ];
+        let is_valid_field_name = matches!(
+            self.token(),
+            Some(
+                Token::Identifier
+                // adapt keywords, but not recommend to use
+                | Token::Namespace
+                | Token::Include
+                | Token::List
+                | Token::Map
+                | Token::Set
+                | Token::Oneway
+                | Token::Required
+                | Token::Optional
+                | Token::Throws
+                | Token::Bool
+                | Token::Byte
+                | Token::I8
+                | Token::I16
+                | Token::I32
+                | Token::I64
+                | Token::String
+                | Token::Binary
+                | Token::Extends
+                | Token::Struct
+                | Token::Double
+                | Token::Service
+                | Token::Enum
+            )
+        );
 
-        if !VALID_TOKENS.iter().any(|valid| self.token() == Some(valid)) {
+        if !is_valid_field_name {
             return Err(self.error(ParseErrorKind::InvalidFieldName));
         }
 
@@ -469,7 +501,7 @@ impl<'a> Parser<'a> {
     where
         F: FnMut(&mut Self) -> Result<T, ParseError>,
     {
-        let mut members = Vec::new();
+        let mut members = Vec::with_capacity(8);
 
         self.consume(Token::LeftBrace)?;
 
@@ -492,18 +524,20 @@ impl<'a> Parser<'a> {
     where
         F: FnMut(&mut Self) -> Result<T, ParseError>,
     {
-        let mut params = Vec::new();
+        let mut params = Vec::with_capacity(4);
         self.consume(Token::LeftParen)?;
 
         loop {
             self.advance();
+            self.skip_separator();
+            self.skip_comments();
             if let Some(Token::RightParen) = self.token() {
                 break;
             }
 
             params.push(parse_param(self)?);
 
-            if let Some(Token::Comma) = self.peek() {
+            if matches!(self.peek(), Some(Token::Comma | Token::Semicolon)) {
                 self.advance();
             }
         }

--- a/creates/rico/src/parser/mod.rs
+++ b/creates/rico/src/parser/mod.rs
@@ -153,7 +153,7 @@ impl<'a> Parser<'a> {
             lexer,
             next_token: None,
             cur_token: None,
-            pending_comments: Vec::new(),
+            pending_comments: Vec::with_capacity(4),
             last_span,
         }
     }
@@ -175,15 +175,20 @@ impl<'a> Parser<'a> {
     ///
     /// Returns a ParseError if the input contains syntax errors or unsupported features.
     pub fn parse(&mut self) -> Result<Document, ParseError> {
-        let mut members = Vec::new();
+        let mut members = Vec::with_capacity(self.lexer.source().len() / 128);
 
         loop {
             self.advance();
+            self.skip_separator();
             self.skip_comments();
+            self.skip_separator();
             if let Some(token) = self.token() {
                 match token {
                     Token::Include => {
                         members.push(DocumentMembers::Include(self.parse_include()?));
+                    }
+                    Token::CppInclude => {
+                        members.push(DocumentMembers::CppInclude(self.parse_cpp_include()?));
                     }
                     Token::Namespace => {
                         members.push(DocumentMembers::Namespace(self.parse_namespace()?));
@@ -215,20 +220,27 @@ impl<'a> Parser<'a> {
     }
 
     fn create_parser_token(&mut self) -> Option<ParserToken<'a>> {
-        self.lexer.next().and_then(|result| {
-            result
-                .map(|token| ParserToken {
-                    text: self.lexer.slice(),
-                    span: self.lexer.span(),
+        let result = self.lexer.next()?;
+        match result {
+            Ok(token) => {
+                let span = self.lexer.span();
+                let text = self.lexer.slice();
+                let start = self.bind_start_position(&span);
+                let end = self.bind_end_position(&span, token);
+
+                Some(ParserToken {
+                    text,
+                    span,
                     token,
-                    start: self.bind_start_position(),
-                    end: self.bind_end_position(),
+                    start,
+                    end,
                 })
-                .map_err(|_| {
-                    self.last_span = self.lexer.span();
-                })
-                .ok()
-        })
+            }
+            Err(_) => {
+                self.last_span = self.lexer.span();
+                None
+            }
+        }
     }
 
     fn advance(&mut self) -> Option<&Token> {
@@ -269,39 +281,39 @@ impl<'a> Parser<'a> {
         return None;
     }
 
-    fn text(&self) -> &str {
+    fn text(&self) -> &'a str {
         if let Some(token) = &self.cur_token {
             return token.text;
         }
         return "";
     }
 
-    fn bind_start_position(&mut self) -> Span {
-        let source = self.lexer.source();
-        let span = self.lexer.span();
-        let start_index = source[..span.start].len();
-        let column = source[self.lexer.extras.1..span.start].len() + 1;
+    fn bind_start_position(&self, span: &logos::Span) -> Span {
         let line = self.lexer.extras.0 + 1;
-        let index = start_index;
-        Span::new(line, column, index)
+        let column = span.start.saturating_sub(self.lexer.extras.1) + 1;
+        Span::new(line, column, span.start)
     }
 
-    fn bind_end_position(&mut self) -> Span {
-        let span = self.lexer.span();
-        let source = self.lexer.source();
-        // handle inner multiple content
-        let newline_count = self.lexer.slice().matches('\n').count();
+    fn bind_end_position(&mut self, span: &logos::Span, token: Token) -> Span {
+        let mut line = self.lexer.extras.0 + 1;
+        let mut line_start = self.lexer.extras.1;
 
-        if newline_count > 0 {
+        if matches!(token, Token::BlockComment) {
+            let mut newline_count = 0;
+            for (offset, byte) in self.lexer.slice().bytes().enumerate() {
+                if byte == b'\n' {
+                    newline_count += 1;
+                    line_start = span.start + offset + 1;
+                }
+            }
             self.lexer.extras.0 += newline_count;
-            self.lexer.extras.1 = self.lexer.span().end;
+            self.lexer.extras.1 = line_start;
+            line = self.lexer.extras.0 + 1;
         }
 
-        let line = self.lexer.extras.0 + 1;
-        let column = source[self.lexer.extras.1..span.end].len() + 1;
-        let index = source[..span.end].len();
+        let column = span.end.saturating_sub(line_start) + 1;
 
-        Span::new(line, column, index)
+        Span::new(line, column, span.end)
     }
 
     fn error(&self, kind: ParseErrorKind) -> ParseError {

--- a/creates/rico/src/parser/token.rs
+++ b/creates/rico/src/parser/token.rs
@@ -53,24 +53,26 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn skip_comments(&mut self) {
         loop {
-            if let Some(token) = self.token() {
-                if token == &Token::LineComment || token == &Token::BlockComment {
-                    self.parser_comments();
-                    self.advance();
-                    continue;
-                }
+            if matches!(self.token(), Some(Token::LineComment | Token::BlockComment)) {
+                self.parser_comments();
+                self.advance();
+                continue;
             }
             break;
         }
     }
 
+    pub(crate) fn skip_comments_discard(&mut self) {
+        while matches!(self.token(), Some(Token::LineComment | Token::BlockComment)) {
+            self.advance();
+        }
+    }
+
     pub(crate) fn skip_separator(&mut self) {
         loop {
-            if let Some(token) = self.token() {
-                if token == &Token::Comma || token == &Token::Semicolon {
-                    self.advance();
-                    continue;
-                }
+            if matches!(self.token(), Some(Token::Comma | Token::Semicolon)) {
+                self.advance();
+                continue;
             }
             break;
         }

--- a/creates/rico/src/parser/types.rs
+++ b/creates/rico/src/parser/types.rs
@@ -16,7 +16,7 @@ impl<'a> Parser<'a> {
         F: Fn(LOC, &str, FieldType) -> FieldType,
     {
         let start_loc = self.start_pos();
-        let slice = self.text().to_owned();
+        let slice = self.text();
 
         self.consume(Token::LeftAngle)?;
         let filed_type = self.parse_field_type()?;
@@ -43,7 +43,7 @@ impl<'a> Parser<'a> {
 
     pub(crate) fn parse_map_type(&mut self) -> Result<FieldType, ParseError> {
         let start_loc = self.start_pos();
-        let slice = self.text().to_owned();
+        let slice = self.text();
 
         self.consume(Token::LeftAngle)?;
         let filed_key_type = self.parse_field_type()?;
@@ -79,6 +79,7 @@ impl<'a> Parser<'a> {
                 Token::Binary
                 | Token::String
                 | Token::Byte
+                | Token::I8
                 | Token::I16
                 | Token::I32
                 | Token::I64

--- a/creates/rico/src/parser/values.rs
+++ b/creates/rico/src/parser/values.rs
@@ -12,11 +12,12 @@ impl<'a> Parser<'a> {
         is_end: fn(&mut Self) -> bool,
         parse_element: impl Fn(&mut Self) -> Result<T, ParseError>,
     ) -> Result<Vec<T>, ParseError> {
-        let mut elements = Vec::new();
+        let mut elements = Vec::with_capacity(4);
 
         loop {
             self.advance();
-            self.skip_comments();
+            self.skip_separator();
+            self.skip_comments_discard();
 
             if is_end(self) {
                 break;
@@ -25,8 +26,8 @@ impl<'a> Parser<'a> {
             let element = parse_element(self)?;
             elements.push(element);
 
-            if let Some(Token::Comma) = self.peek() {
-                self.consume(Token::Comma)?;
+            if matches!(self.peek(), Some(Token::Comma | Token::Semicolon)) {
+                self.advance();
             }
         }
 

--- a/creates/rico/src/writer/document.rs
+++ b/creates/rico/src/writer/document.rs
@@ -28,6 +28,12 @@ impl Writer {
         writeln!(output, "include {}", inc.name.value).unwrap();
     }
 
+    /// Writes a C++ include statement to the output string.
+    pub(crate) fn write_cpp_include(&mut self, output: &mut String, inc: &CppInclude) {
+        self.write_comments(output, &inc.comments);
+        writeln!(output, "cpp_include {}", inc.name.value).unwrap();
+    }
+
     /// Writes a constant definition to the output string.
     pub(crate) fn write_const(&mut self, output: &mut String, c: &Const) {
         self.write_comments(output, &c.comments);

--- a/creates/rico/src/writer/mod.rs
+++ b/creates/rico/src/writer/mod.rs
@@ -98,6 +98,7 @@ impl Writer {
             match member {
                 DocumentMembers::Namespace(ns) => self.write_namespace(&mut output, ns),
                 DocumentMembers::Include(inc) => self.write_include(&mut output, inc),
+                DocumentMembers::CppInclude(inc) => self.write_cpp_include(&mut output, inc),
                 DocumentMembers::Const(c) => self.write_const(&mut output, c),
                 DocumentMembers::Typedef(td) => self.write_typedef(&mut output, td),
                 DocumentMembers::Enum(e) => self.write_enum(&mut output, e),

--- a/creates/rico/tests/unit/parser_test.rs
+++ b/creates/rico/tests/unit/parser_test.rs
@@ -1,141 +1,140 @@
+use rico::DocumentMembers;
+use rico::FieldInitialValue;
+use rico::FieldType;
+use rico::Parser;
 
-    use rico::DocumentMembers;
-    use rico::FieldInitialValue;
-    use rico::FieldType;
-    use rico::Parser;
+#[test]
+fn test_parse_namespace() {
+    let input = "namespace rs demo";
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-    #[test]
-    fn test_parse_namespace() {
-        let input = "namespace rs demo";
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
-
-        match &result.members[0] {
-            DocumentMembers::Namespace(ns) => {
-                assert_eq!(ns.scope.value, "rs");
-                assert_eq!(ns.name.value, "demo");
-            }
-            _ => panic!("Expected Namespace"),
+    match &result.members[0] {
+        DocumentMembers::Namespace(ns) => {
+            assert_eq!(ns.scope.value, "rs");
+            assert_eq!(ns.name.value, "demo");
         }
+        _ => panic!("Expected Namespace"),
     }
+}
 
-    #[test]
-    fn test_parse_struct() {
-        let input = r#"
+#[test]
+fn test_parse_struct() {
+    let input = r#"
             struct User {
                 1: string name
                 2: i32 age
                 3: optional list<string> tags
             }
         "#;
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        match &result.members[0] {
-            DocumentMembers::Struct(s) => {
-                assert_eq!(s.name.value, "User");
-                assert_eq!(s.members.len(), 3);
-                assert_eq!(s.members[0].name.value, "name");
-                assert_eq!(s.members[1].name.value, "age");
-                assert_eq!(s.members[2].name.value, "tags");
-            }
-            _ => panic!("Expected Struct"),
+    match &result.members[0] {
+        DocumentMembers::Struct(s) => {
+            assert_eq!(s.name.value, "User");
+            assert_eq!(s.members.len(), 3);
+            assert_eq!(s.members[0].name.value, "name");
+            assert_eq!(s.members[1].name.value, "age");
+            assert_eq!(s.members[2].name.value, "tags");
         }
+        _ => panic!("Expected Struct"),
     }
+}
 
-    #[test]
-    fn test_parse_enum() {
-        let input = r#"
+#[test]
+fn test_parse_enum() {
+    let input = r#"
             enum Status {
                 ACTIVE = 1
                 INACTIVE = 2
                 DELETED = 3 (deprecated = "use INACTIVE instead")
             }
         "#;
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        match &result.members[0] {
-            DocumentMembers::Enum(e) => {
-                assert_eq!(e.name.value, "Status");
-                assert_eq!(e.members.len(), 3);
-                assert_eq!(e.members[0].name.value, "ACTIVE");
-                assert_eq!(e.members[1].name.value, "INACTIVE");
-                assert_eq!(e.members[2].name.value, "DELETED");
-            }
-            _ => panic!("Expected Enum"),
+    match &result.members[0] {
+        DocumentMembers::Enum(e) => {
+            assert_eq!(e.name.value, "Status");
+            assert_eq!(e.members.len(), 3);
+            assert_eq!(e.members[0].name.value, "ACTIVE");
+            assert_eq!(e.members[1].name.value, "INACTIVE");
+            assert_eq!(e.members[2].name.value, "DELETED");
         }
+        _ => panic!("Expected Enum"),
     }
+}
 
-    #[test]
-    fn test_parse_service() {
-        let input = r#"
+#[test]
+fn test_parse_service() {
+    let input = r#"
             service UserService {
                 User getUser(1: i32 id) throws (1: UserNotFound notFound)
                 void createUser(1: User user)
                 oneway void notify(1: string message)
             }
         "#;
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        match &result.members[0] {
-            DocumentMembers::Service(s) => {
-                assert_eq!(s.name.value, "UserService");
-                assert_eq!(s.members.len(), 3);
-                assert_eq!(s.members[0].name.value, "getUser");
-                assert_eq!(s.members[1].name.value, "createUser");
-                assert_eq!(s.members[2].name.value, "notify");
-                assert!(s.members[2].oneway);
-            }
-            _ => panic!("Expected Service"),
+    match &result.members[0] {
+        DocumentMembers::Service(s) => {
+            assert_eq!(s.name.value, "UserService");
+            assert_eq!(s.members.len(), 3);
+            assert_eq!(s.members[0].name.value, "getUser");
+            assert_eq!(s.members[1].name.value, "createUser");
+            assert_eq!(s.members[2].name.value, "notify");
+            assert!(s.members[2].oneway);
         }
+        _ => panic!("Expected Service"),
     }
+}
 
-    #[test]
-    fn test_parse_typedef() {
-        let input = "typedef i64 UserId";
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+#[test]
+fn test_parse_typedef() {
+    let input = "typedef i64 UserId";
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        match &result.members[0] {
-            DocumentMembers::Typedef(t) => {
-                assert_eq!(t.name.value, "UserId");
-                match &t.field_type {
-                    FieldType::CommonType(c) => assert_eq!(c.value, "i64"),
-                    _ => panic!("Expected CommonType"),
-                }
+    match &result.members[0] {
+        DocumentMembers::Typedef(t) => {
+            assert_eq!(t.name.value, "UserId");
+            match &t.field_type {
+                FieldType::CommonType(c) => assert_eq!(c.value, "i64"),
+                _ => panic!("Expected CommonType"),
             }
-            _ => panic!("Expected Typedef"),
         }
+        _ => panic!("Expected Typedef"),
     }
+}
 
-    #[test]
-    fn test_parse_const() {
-        let input = r#"
+#[test]
+fn test_parse_const() {
+    let input = r#"
             const i32 MAX_USERS = 1000
             const string VERSION = "1.0.0"
             const list<string> ADMINS = ["admin", "root"]
         "#;
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        assert_eq!(result.members.len(), 3);
-        match &result.members[0] {
-            DocumentMembers::Const(c) => {
-                assert_eq!(c.name.value, "MAX_USERS");
-                match &c.value {
-                    FieldInitialValue::ConstValue(v) => assert_eq!(v.value, "1000"),
-                    _ => panic!("Expected ConstValue"),
-                }
+    assert_eq!(result.members.len(), 3);
+    match &result.members[0] {
+        DocumentMembers::Const(c) => {
+            assert_eq!(c.name.value, "MAX_USERS");
+            match &c.value {
+                FieldInitialValue::ConstValue(v) => assert_eq!(v.value, "1000"),
+                _ => panic!("Expected ConstValue"),
             }
-            _ => panic!("Expected Const"),
         }
+        _ => panic!("Expected Const"),
     }
+}
 
-    #[test]
-    fn test_parse_comments() {
-        let input = r#"
+#[test]
+fn test_parse_comments() {
+    let input = r#"
             // Service comment
             /* Block comment */
             service UserService {
@@ -143,50 +142,199 @@
                 void createUser(1: User user)
             }
         "#;
-        let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
 
-        match &result.members[0] {
-            DocumentMembers::Service(s) => {
-                assert_eq!(s.comments.len(), 2);
-                assert_eq!(s.members[0].comments.len(), 1);
-            }
-            _ => panic!("Expected Service"),
+    match &result.members[0] {
+        DocumentMembers::Service(s) => {
+            assert_eq!(s.comments.len(), 2);
+            assert_eq!(s.members[0].comments.len(), 1);
         }
+        _ => panic!("Expected Service"),
     }
+}
 
-    #[test]
-    fn test_parse_annotations() {
-        let input = r#"
+#[test]
+fn test_parse_annotations() {
+    let input = r#"
             struct User {
                 1: string name (max_length = "100")
                 2: i32 age (min = "0", max = "150")
             }
         "#;
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
+
+    match &result.members[0] {
+        DocumentMembers::Struct(s) => {
+            assert!(s.members[0].annotations.is_some());
+            assert!(s.members[1].annotations.is_some());
+        }
+        _ => panic!("Expected Struct"),
+    }
+}
+
+#[test]
+fn test_parse_errors() {
+    let invalid_inputs = vec![
+        "struct {}",                       // Missing struct name
+        "enum Status { ACTIVE = }",        // Invalid enum value
+        "const string NAME",               // Missing const value
+        "service UserService { invalid }", // Invalid service method
+    ];
+
+    for input in invalid_inputs {
         let mut parser = Parser::new(input);
-        let result = parser.parse().unwrap();
+        assert!(parser.parse().is_err());
+    }
+}
 
-        match &result.members[0] {
-            DocumentMembers::Struct(s) => {
-                assert!(s.members[0].annotations.is_some());
-                assert!(s.members[1].annotations.is_some());
+#[test]
+fn test_parse_common_thrift_syntax_extensions() {
+    let input = r#"
+            cpp_include "common/types.h"
+            namespace * demo.shared
+
+            struct Metrics {
+                1: i8 level = -1,
+                2: double ratio = 1e-3
+            } (cpp.type = "Metrics")
+        "#;
+
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
+
+    match &result.members[0] {
+        DocumentMembers::CppInclude(inc) => {
+            assert_eq!(inc.name.value, "\"common/types.h\"");
+        }
+        _ => panic!("Expected CppInclude"),
+    }
+
+    match &result.members[1] {
+        DocumentMembers::Namespace(ns) => {
+            assert_eq!(ns.scope.value, "*");
+            assert_eq!(ns.name.value, "demo.shared");
+        }
+        _ => panic!("Expected Namespace"),
+    }
+
+    match &result.members[2] {
+        DocumentMembers::Struct(s) => {
+            assert_eq!(s.members[0].name.value, "level");
+            assert_eq!(s.members[1].name.value, "ratio");
+            assert!(s.annotations.is_some());
+        }
+        _ => panic!("Expected Struct"),
+    }
+}
+
+#[test]
+fn test_parse_benchmark_fixture_covers_supported_syntax() {
+    let input = include_str!("../../../../apps/benchmark/benches/fixtures/large.thrift");
+    let mut parser = Parser::new(input);
+    let result = parser.parse().unwrap();
+
+    assert_eq!(result.members.len(), 34);
+
+    let mut namespaces = 0;
+    let mut typedefs = 0;
+    let mut consts = 0;
+    let mut enums = 0;
+    let mut structs = 0;
+    let mut unions = 0;
+    let mut exceptions = 0;
+    let mut services = 0;
+    let mut saw_cpp_include = false;
+    let mut saw_include = false;
+
+    for member in &result.members {
+        match member {
+            DocumentMembers::CppInclude(inc) => {
+                saw_cpp_include = true;
+                assert_eq!(inc.name.value, "\"generated/rico_types.h\"");
+                assert_eq!(inc.comments.len(), 2);
+                assert!(inc.comments[1].value.contains("multiple lines"));
             }
-            _ => panic!("Expected Struct"),
+            DocumentMembers::Include(inc) => {
+                saw_include = true;
+                assert_eq!(inc.name.value, "\"shared/common.thrift\"");
+            }
+            DocumentMembers::Namespace(ns) => {
+                namespaces += 1;
+                if ns.scope.value == "*" {
+                    assert_eq!(ns.name.value, "rico.fixtures");
+                }
+            }
+            DocumentMembers::Typedef(_) => typedefs += 1,
+            DocumentMembers::Const(c) => {
+                consts += 1;
+                if c.name.value == "CONST_MAP" {
+                    assert!(c.comments.is_empty());
+                }
+            }
+            DocumentMembers::Enum(e) => {
+                enums += 1;
+                if e.name.value == "Lifecycle" {
+                    assert_eq!(e.members.len(), 4);
+                    assert!(e.members[1].annotations.is_some());
+                    assert!(e.annotations.is_some());
+                }
+            }
+            DocumentMembers::Struct(s) => {
+                structs += 1;
+                if s.name.value == "PrimitiveBag" {
+                    assert_eq!(s.members.len(), 14);
+                    assert!(s.annotations.is_some());
+                    assert!(s.members[0].annotations.is_some());
+                    assert_eq!(s.members[13].comments.len(), 1);
+                }
+                if s.name.value == "CommentStress" {
+                    assert_eq!(s.members.len(), 3);
+                    assert!(s.members[1].comments.is_empty());
+                    assert_eq!(s.members[2].comments.len(), 1);
+                }
+            }
+            DocumentMembers::Union(u) => {
+                unions += 1;
+                assert_eq!(u.name.value, "SearchKey");
+                assert!(u.annotations.is_some());
+            }
+            DocumentMembers::Exception(e) => {
+                exceptions += 1;
+                assert_eq!(e.name.value, "ValidationError");
+                assert!(e.annotations.is_some());
+            }
+            DocumentMembers::Service(s) => {
+                services += 1;
+                if s.name.value == "UserService" {
+                    assert_eq!(
+                        s.extends.as_ref().map(|extends| extends.value.as_str()),
+                        Some("BaseService")
+                    );
+                    assert_eq!(s.members.len(), 3);
+                    assert_eq!(s.members[0].params.len(), 2);
+                    assert_eq!(s.members[0].params[1].comments.len(), 1);
+                    assert!(s.members[0]
+                        .throws
+                        .as_ref()
+                        .is_some_and(|throws| throws.len() == 1));
+                    assert!(s.members[0].annotations.is_some());
+                    assert!(s.members[1].oneway);
+                    assert!(s.annotations.is_some());
+                }
+            }
         }
     }
 
-    #[test]
-    fn test_parse_errors() {
-        let invalid_inputs = vec![
-            "struct {}",                       // Missing struct name
-            "enum Status { ACTIVE = }",        // Invalid enum value
-            "const string NAME",               // Missing const value
-            "service UserService { invalid }", // Invalid service method
-        ];
-
-        for input in invalid_inputs {
-            let mut parser = Parser::new(input);
-            assert!(parser.parse().is_err());
-        }
-    }
-
+    assert!(saw_cpp_include);
+    assert!(saw_include);
+    assert_eq!(namespaces, 4);
+    assert_eq!(typedefs, 3);
+    assert_eq!(consts, 16);
+    assert_eq!(enums, 2);
+    assert_eq!(structs, 3);
+    assert_eq!(unions, 1);
+    assert_eq!(exceptions, 1);
+    assert_eq!(services, 2);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react@19.0.2)(react@19.0.0)
       '@rico-core/parser':
-        specifier: workspace:*
-        version: link:../../wasm/rico
+        specifier: ^0.0.5
+        version: 0.0.5
       '@uiw/codemirror-theme-github':
         specifier: ^4.23.7
         version: 4.23.7(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)
@@ -213,6 +213,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@rico-core/parser@0.0.5':
+    resolution: {integrity: sha512-L2GdcU/gRzTdmFroAKgF78uuy6MLCYe40R6eWXTeaaid7oVq2cUrvhV2XYdxwiW0DWJ+ZEwvUyXDIwwo6uhiaA==}
 
   '@rsbuild/core@1.1.13':
     resolution: {integrity: sha512-XBL2hrin8731W6iTGGL+x3cv07n4vm2D7u6XHRwtQkRfySzAqGx7ThlQLdNX/dJwfsoQrYQuWl/qzaljjXtGtg==}
@@ -1051,6 +1054,8 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.2
+
+  '@rico-core/parser@0.0.5': {}
 
   '@rsbuild/core@1.1.13':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1(@types/react@19.0.2)(react@19.0.0)
       '@rico-core/parser':
-        specifier: 0.0.3
-        version: 0.0.3
+        specifier: workspace:*
+        version: link:../../wasm/rico
       '@uiw/codemirror-theme-github':
         specifier: ^4.23.7
         version: 4.23.7(@codemirror/language@6.10.8)(@codemirror/state@6.5.0)(@codemirror/view@6.36.1)
@@ -213,9 +213,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  '@rico-core/parser@0.0.3':
-    resolution: {integrity: sha512-nt7gFf8knHCnmGE7lPBBvAhBiStmhDFNA1X2oTgMaL0Kv6qhy+WxfLAyuqHU7DUJkz/dzShs4Z2f/KqJmBZiwA==}
 
   '@rsbuild/core@1.1.13':
     resolution: {integrity: sha512-XBL2hrin8731W6iTGGL+x3cv07n4vm2D7u6XHRwtQkRfySzAqGx7ThlQLdNX/dJwfsoQrYQuWl/qzaljjXtGtg==}
@@ -1054,8 +1051,6 @@ snapshots:
       react: 19.0.0
     optionalDependencies:
       '@types/react': 19.0.2
-
-  '@rico-core/parser@0.0.3': {}
 
   '@rsbuild/core@1.1.13':
     dependencies:

--- a/wasm/rico/package.json
+++ b/wasm/rico/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rico-core/parser",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "WebAssembly bindings for Rico - A high-performance Apache Thrift IDL parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/wasm/rico/package.json
+++ b/wasm/rico/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/xnmeet/rico"
+    "url": "git+https://github.com/xnmeet/rico.git"
   },
   "scripts": {
     "clean": "rm -rf dist src/wasm",

--- a/wasm/rico/src/error.rs
+++ b/wasm/rico/src/error.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use serde_json;
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Location {
     line: usize,
     column: usize,
@@ -71,18 +72,15 @@ fn get_error_location(e: &impl Diagnostic, source: &str) -> Option<Location> {
 fn calculate_location(offset: usize, length: usize, source: &str) -> Location {
     let lines: Vec<&str> = source.lines().collect();
 
-    // Calculate line number and column by counting newlines
     let mut line = 1;
     let mut last_newline = 0;
-    let mut pos = 0;
-    for (i, c) in source[..offset].chars().enumerate() {
-        if c == '\n' {
+    for (i, byte) in source.as_bytes()[..offset].iter().enumerate() {
+        if *byte == b'\n' {
             line += 1;
             last_newline = i + 1;
         }
-        pos = i;
     }
-    let column = pos - last_newline + 1;
+    let column = offset.saturating_sub(last_newline) + 1;
 
     Location {
         line,

--- a/wasm/rico/src/index.ts
+++ b/wasm/rico/src/index.ts
@@ -1,4 +1,7 @@
-import init, { Parser, Writer } from './wasm/rico_wasm';
+import init, {
+  parse as parseWasm,
+  write as writeWasm
+} from './wasm/rico_wasm';
 import type { Document, ParseError } from './types';
 
 export class RicoError extends Error {
@@ -15,64 +18,79 @@ export class RicoError extends Error {
 
     super(message);
     this.name = 'RicoError';
-    // Prevent V8 from collecting stack trace
-    Error.captureStackTrace(this, RicoError);
+    if ('captureStackTrace' in Error) {
+      Error.captureStackTrace(this, RicoError);
+    }
   }
 }
 
 export class Rico {
   private static initialized = false;
 
-  static async initialize(): Promise<void> {
+  static async initialize(moduleOrPath?: Parameters<typeof init>[0]): Promise<void> {
     if (!Rico.initialized) {
-      await init();
+      await init(moduleOrPath);
       Rico.initialized = true;
     }
   }
 
-  static parse(input: string): Promise<string>;
-  static parse(input: string, toString: false): Promise<Document>;
-  static parse(input: string, toString: true): Promise<string>;
-  static parse(input: string, toString?: boolean): Promise<Document | string> {
+  static parse(input: string): string;
+  static parse(input: string, toString: false): Document;
+  static parse(input: string, toString: true): string;
+  static parse(input: string, toString?: boolean): Document | string {
     if (!Rico.initialized) {
       throw new Error('Rico is not initialized. Call Rico.initialize() first.');
     }
-    const parser = new Parser(input);
     toString = typeof toString === 'undefined' ? true : toString;
     try {
-      const result = parser.parse();
-      return Promise.resolve(!toString ? JSON.parse(result) : result);
+      const result = parseWasm(input);
+      return !toString ? JSON.parse(result) : result;
     } catch (error) {
-      try {
-        const parserError = JSON.parse(error as string);
-        if (parserError && 'kind' in parserError) {
-          throw new RicoError(error as ParseError);
-        }
-      } finally {
-        throw error;
-      }
+      throw toRicoError(error);
     }
+  }
+
+  static parseObject(input: string): Document {
+    return Rico.parse(input, false);
+  }
+
+  static parseString(input: string): string {
+    return Rico.parse(input, true);
   }
 
   static write(ast: Document): string {
     if (!Rico.initialized) {
       throw new Error('Rico is not initialized. Call Rico.initialize() first.');
     }
-    const writer = new Writer();
     try {
-      return writer.write(JSON.stringify(ast));
+      return writeWasm(JSON.stringify(ast));
     } catch (error) {
-      try {
-        const parserError = JSON.parse(error as string);
-        if (parserError && 'kind' in parserError) {
-          throw new RicoError(error as ParseError);
-        }
-      } finally {
-        throw error;
-      }
+      throw toRicoError(error);
     }
   }
 }
 
+function toRicoError(error: unknown): unknown {
+  if (typeof error !== 'string') {
+    return error;
+  }
+
+  try {
+    const parserError = JSON.parse(error) as ParseError;
+    if (parserError && 'kind' in parserError) {
+      return new RicoError(parserError);
+    }
+  } catch {
+    // Fall through to the original WASM error string.
+  }
+
+  return error;
+}
+
+export const initialize = Rico.initialize.bind(Rico);
+export const parse = Rico.parse.bind(Rico);
+export const parseObject = Rico.parseObject.bind(Rico);
+export const parseString = Rico.parseString.bind(Rico);
+export const write = Rico.write.bind(Rico);
 export * from './types';
 export default Rico;

--- a/wasm/rico/src/types.ts
+++ b/wasm/rico/src/types.ts
@@ -1,7 +1,11 @@
 export type NodeType =
   | 'ThriftDocument'
+  | 'ThriftErrors'
+  | 'Identifier'
+  | 'FieldID'
   | 'NamespaceDefinition'
   | 'IncludeDefinition'
+  | 'CppIncludeDefinition'
   | 'ConstDefinition'
   | 'TypedefDefinition'
   | 'EnumDefinition'
@@ -15,13 +19,54 @@ export type NodeType =
   | 'CommentBlock'
   | 'Annotation'
   | 'Annotations'
-  | 'CommonType'
-  | 'CollectionType'
+  | 'FieldType'
+  | 'BaseType'
+  | 'SetType'
+  | 'ListType'
   | 'MapType'
   | 'ConstValue'
+  | 'IntConstant'
+  | 'DoubleConstant'
   | 'ConstList'
   | 'ConstMap'
-  | 'PropertyAssignment';
+  | 'StringLiteral'
+  | 'IntegerLiteral'
+  | 'FloatLiteral'
+  | 'HexLiteral'
+  | 'ExponentialLiteral'
+  | 'BooleanLiteral'
+  | 'PropertyAssignment'
+  | 'NamespaceKeyword'
+  | 'IncludeKeyword'
+  | 'CppIncludeKeyword'
+  | 'ExceptionKeyword'
+  | 'ServiceKeyword'
+  | 'ExtendsKeyword'
+  | 'RequiredKeyword'
+  | 'OptionalKeyword'
+  | 'FalseKeyword'
+  | 'TrueKeyword'
+  | 'ConstKeyword'
+  | 'DoubleKeyword'
+  | 'StructKeyword'
+  | 'TypedefKeyword'
+  | 'UnionKeyword'
+  | 'StringKeyword'
+  | 'BinaryKeyword'
+  | 'BoolKeyword'
+  | 'ByteKeyword'
+  | 'EnumKeyword'
+  | 'ListKeyword'
+  | 'SetKeyword'
+  | 'MapKeyword'
+  | 'I8Keyword'
+  | 'I16Keyword'
+  | 'I32Keyword'
+  | 'I64Keyword'
+  | 'ThrowsKeyword'
+  | 'VoidKeyword'
+  | 'OnewayKeyword'
+  | 'EOF';
 
 export interface Span {
   line: number;
@@ -48,6 +93,7 @@ export interface Document {
 export type DocumentMember =
   | Namespace
   | Include
+  | CppInclude
   | Const
   | Typedef
   | Enum
@@ -90,6 +136,11 @@ export interface Namespace extends BaseNode {
 
 export interface Include extends BaseNode {
   kind: 'IncludeDefinition';
+  name: Common<string>;
+}
+
+export interface CppInclude extends BaseNode {
+  kind: 'CppIncludeDefinition';
   name: Common<string>;
 }
 
@@ -190,7 +241,7 @@ export interface FieldMapType {
 }
 
 export type FieldType =
-  | { kind: 'CommonType'; value: string; loc: LOC }
+  | Common<string>
   | FieldListType
   | FieldSetType
   | FieldMapType;

--- a/wasm/rico/src/utils.rs
+++ b/wasm/rico/src/utils.rs
@@ -8,4 +8,3 @@ pub fn set_panic_hook() {
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
 }
-

--- a/wasm/rico/src/wasm.rs
+++ b/wasm/rico/src/wasm.rs
@@ -5,6 +5,31 @@ use crate::error::RicoError;
 use crate::utils::set_panic_hook;
 use serde_json;
 
+fn parse_to_json(input: &str) -> Result<String, String> {
+    let mut parser = RicoParser::new(input);
+    parser
+        .parse()
+        .map_err(|e| RicoError::parse(e, input).to_string())
+        .and_then(|ast| {
+            serde_json::to_string(&ast).map_err(|e| RicoError::serialization(e).to_string())
+        })
+}
+
+#[wasm_bindgen(js_name = parse)]
+pub fn parse(input: &str) -> Result<String, String> {
+    set_panic_hook();
+    parse_to_json(input)
+}
+
+#[wasm_bindgen(js_name = write)]
+pub fn write(ast: &str) -> Result<String, String> {
+    set_panic_hook();
+    let ast: rico::Document =
+        serde_json::from_str(ast).map_err(|e| RicoError::deserialization(e).to_string())?;
+
+    Ok(RicoWriter::new().write(&ast))
+}
+
 #[wasm_bindgen]
 pub struct Parser {
     input: String,
@@ -20,16 +45,7 @@ impl Parser {
 
     #[wasm_bindgen]
     pub fn parse(&mut self) -> Result<String, String> {
-        let mut parser = RicoParser::new(&self.input);
-        match parser.parse() {
-            Ok(ast) => {
-                let value = serde_json::to_string(&ast)
-                    .map_err(|e| RicoError::serialization(e).to_string());
-
-                return value;
-            }
-            Err(e) => Err(RicoError::parse(e, &self.input).to_string()),
-        }
+        parse_to_json(&self.input)
     }
 }
 
@@ -49,7 +65,7 @@ impl Writer {
     }
 
     #[wasm_bindgen]
-    pub fn write(&mut self, ast: &str) -> Result<String, JsValue> {
+    pub fn write(&mut self, ast: &str) -> Result<String, String> {
         let ast: rico::Document =
             serde_json::from_str(&ast).map_err(|e| RicoError::deserialization(e).to_string())?;
 


### PR DESCRIPTION
## Summary
- Extend parser/writer coverage for practical Thrift IDL syntax: `cpp_include`, `namespace *`, `i8`, separators, comments around values, annotations, defaults, and scientific numeric literals.
- Keep the existing JSON AST shape stable while tightening parser hot paths and updating WASM/JS exports, errors, and TypeScript types.
- Switch the playground to the workspace parser package, document supported syntax/non-goals, and refresh the benchmark fixture plus coverage test.

## Verification
- `cargo fmt --all`
- `cargo test --workspace`
- `cargo check -p rico-wasm --target wasm32-unknown-unknown`
- `pnpm --filter rico-playground build`
- `cargo bench -p rico-benchmark --bench parser_benchmark -- --noplot`

## Benchmark
Criterion on the refreshed supported-syntax fixture:

| Fixture | Parse | JSON output | Pretty JSON output |
| --- | ---: | ---: | ---: |
| 143 lines | 14.065 us | 64.655 us | 144.89 us |
| 1,430 lines | 142.83 us | 636.98 us | 1.4188 ms |
| 4,290 lines | 427.12 us | 1.9324 ms | 4.5096 ms |
| 7,150 lines | 717.68 us | 3.2037 ms | 7.4033 ms |
| 14,300 lines | 1.4285 ms | 6.6792 ms | 14.617 ms |